### PR TITLE
feat: add scroll-linked animations using Lenis + Framer Motion

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -36,3 +36,25 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+
+// Framer Motion's useScroll/useTransform uses the Web Animations API
+Element.prototype.animate = jest.fn().mockImplementation(() => ({
+  finished: Promise.resolve(),
+  cancel: jest.fn(),
+  pause: jest.fn(),
+  play: jest.fn(),
+  reverse: jest.fn(),
+  finish: jest.fn(),
+  onfinish: null,
+  oncancel: null,
+  currentTime: 0,
+  playState: "finished",
+  effect: null,
+  timeline: null,
+  commitStyles: jest.fn(),
+  persist: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+  updatePlaybackRate: jest.fn(),
+}));

--- a/sections/banner/banner.tsx
+++ b/sections/banner/banner.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useRef } from "react";
 import Link from "next/link";
-import { motion } from "framer-motion";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useReducedMotion,
+} from "framer-motion";
 import { ArrowUpRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -21,6 +26,19 @@ const Banner = ({
   downloadable,
 }: BannerProps) => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sectionRef = useRef<HTMLElement>(null);
+  const prefersReduced = useReducedMotion();
+
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start start", "end start"],
+  });
+
+  // Parallax: grid moves at 50% speed
+  const bgY = useTransform(scrollYProgress, [0, 1], prefersReduced ? [0, 0] : [0, 150]);
+  // Text fades out and shifts up as you scroll past
+  const textOpacity = useTransform(scrollYProgress, [0, 0.6], prefersReduced ? [1, 1] : [1, 0]);
+  const textY = useTransform(scrollYProgress, [0, 0.6], prefersReduced ? [0, 0] : [0, -50]);
 
   useEffect(() => {
     let toRotate: string | null;
@@ -81,21 +99,34 @@ const Banner = ({
 
   return (
     <motion.section
+      ref={sectionRef}
       id="banner"
-      className="flex min-h-[80vh] flex-col items-center justify-center overflow-x-hidden border-b-2 border-border py-16 md:py-24"
+      className="relative flex min-h-[80vh] flex-col items-center justify-center overflow-hidden border-b-2 border-border py-16 md:py-24"
       style={{
         backgroundColor: "var(--banner-bg)",
-        backgroundImage: `
-          linear-gradient(to right, var(--banner-grid) 1px, transparent 1px),
-          linear-gradient(to bottom, var(--banner-grid) 1px, transparent 1px)
-        `,
-        backgroundSize: "24px 24px",
       }}
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
-      <div className="container flex flex-col items-center justify-center gap-6 text-center md:gap-8">
+      {/* Parallax grid background */}
+      <motion.div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: `
+            linear-gradient(to right, var(--banner-grid) 1px, transparent 1px),
+            linear-gradient(to bottom, var(--banner-grid) 1px, transparent 1px)
+          `,
+          backgroundSize: "24px 24px",
+          y: bgY,
+        }}
+      />
+
+      {/* Text content with scroll-linked fade */}
+      <motion.div
+        className="container relative z-10 flex flex-col items-center justify-center gap-6 text-center md:gap-8"
+        style={{ opacity: textOpacity, y: textY }}
+      >
         <motion.div
           className="flex flex-col items-center gap-4 md:gap-6"
           initial={{ opacity: 0, y: 10 }}
@@ -144,7 +175,7 @@ const Banner = ({
             </Button>
           )}
         </motion.div>
-      </div>
+      </motion.div>
     </motion.section>
   );
 };

--- a/sections/footer/footer.tsx
+++ b/sections/footer/footer.tsx
@@ -1,65 +1,81 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { useRef } from "react";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useReducedMotion,
+} from "framer-motion";
 import Profile from "../../components/profile/profile";
 
 const Footer = ({
   profiles,
 }: {
   profiles: { name: string; url: string }[];
-}) => (
-  <motion.footer
-    className="container border-t-2 border-border bg-secondary-background py-8 shadow-shadow"
-    initial={{ opacity: 0 }}
-    whileInView={{ opacity: 1 }}
-    viewport={{ once: true, margin: "-20px" }}
-    transition={{ duration: 0.4 }}
-  >
-    <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
-      <div className="flex flex-col">
-        <h3 className="mb-2 text-2xl font-bold text-foreground">
-          Thank you for stopping by!
-        </h3>
-        <p className="mb-4 text-foreground md:mb-0">
-          Let&apos;s get in touch on any of these platforms.
-        </p>
+}) => {
+  const footerRef = useRef<HTMLElement>(null);
+  const prefersReduced = useReducedMotion();
+
+  const { scrollYProgress } = useScroll({
+    target: footerRef,
+    offset: ["-0.2 1", "0.2 1"],
+  });
+
+  const opacity = useTransform(scrollYProgress, [0, 1], prefersReduced ? [1, 1] : [0, 1]);
+  const y = useTransform(scrollYProgress, [0, 1], prefersReduced ? [0, 0] : [20, 0]);
+
+  return (
+    <motion.footer
+      ref={footerRef}
+      className="container border-t-2 border-border bg-secondary-background py-8 shadow-shadow"
+      style={{ opacity, y }}
+    >
+      <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
+        <div className="flex flex-col">
+          <h3 className="mb-2 text-2xl font-bold text-foreground">
+            Thank you for stopping by!
+          </h3>
+          <p className="mb-4 text-foreground md:mb-0">
+            Let&apos;s get in touch on any of these platforms.
+          </p>
+        </div>
+        <div className="flex gap-4">
+          {profiles.length > 0 &&
+            profiles.map((profile) => (
+              <Profile
+                key={profile.name}
+                url={profile.url}
+                name={profile.name}
+                className="text-main-foreground"
+              />
+            ))}
+        </div>
       </div>
-      <div className="flex gap-4">
-        {profiles.length > 0 &&
-          profiles.map((profile) => (
-            <Profile
-              key={profile.name}
-              url={profile.url}
-              name={profile.name}
-              className="text-main-foreground"
-            />
-           
-          ))}
-      </div>
-    </div>
-    <hr className="my-6 border-border" />
-    <div className="flex flex-col gap-2 text-sm text-foreground sm:flex-row sm:justify-between">
-      <span>
-        &copy; {new Date().getFullYear()}{" "}
+      <hr className="my-6 border-border" />
+      <div className="flex flex-col gap-2 text-sm text-foreground sm:flex-row sm:justify-between">
+        <span>
+          &copy; {new Date().getFullYear()}{" "}
+          <a
+            href="https://linkedin.com/in/ps011"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:no-underline"
+          >
+            Prasheel
+          </a>
+        </span>
         <a
-          href="https://linkedin.com/in/ps011"
+          href="https://github.com/ps011/ps11/LICENSE.md"
           target="_blank"
           rel="noreferrer"
           className="underline hover:no-underline"
         >
-          Prasheel
+          License
         </a>
-      </span>
-      <a
-        href="https://github.com/ps011/ps11/LICENSE.md"
-        target="_blank"
-        rel="noreferrer"
-        className="underline hover:no-underline"
-      >
-        License
-      </a>
-    </div>
-  </motion.footer>
-);
+      </div>
+    </motion.footer>
+  );
+};
 
 export default Footer;

--- a/sections/map/map.tsx
+++ b/sections/map/map.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import React, { memo, useState, useEffect, useCallback } from "react";
+import React, { memo, useRef, useState, useEffect, useCallback } from "react";
 import {
   ComposableMap,
   Geographies,
   Geography,
 } from "react-simple-maps";
-import { motion } from "framer-motion";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useReducedMotion,
+} from "framer-motion";
 import Section from "../../components/tailwind/section";
 
 const ComposableMapComponent = ComposableMap as React.ComponentType<{
@@ -27,6 +32,19 @@ interface TooltipState {
 }
 
 const Map = ({ countriesVisited }: { countriesVisited: string[] }) => {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const prefersReduced = useReducedMotion();
+
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["-0.2 1", "0.15 1"],
+  });
+
+  const scale = useTransform(scrollYProgress, [0, 1], prefersReduced ? [1, 1] : [0.95, 1]);
+  const opacity = useTransform(scrollYProgress, [0, 1], prefersReduced ? [1, 1] : [0, 1]);
+  const blur = useTransform(scrollYProgress, [0, 1], prefersReduced ? [0, 0] : [4, 0]);
+  const filterBlur = useTransform(blur, (v) => `blur(${v}px)`);
+
   const [tooltip, setTooltip] = useState<TooltipState>({
     visible: false,
     x: 0,
@@ -78,10 +96,8 @@ const Map = ({ countriesVisited }: { countriesVisited: string[] }) => {
   return (
     <Section id="map" container>
       <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, margin: "-40px" }}
-        transition={{ duration: 0.4 }}
+        ref={sectionRef}
+        style={{ opacity, scale, filter: filterBlur }}
       >
         {/* Header row */}
         <div className="mb-6 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
Replace static one-shot animations with scroll-progress-driven effects:
- Banner: parallax grid background + text fade-out on scroll
- Map: zoom-in with blur-to-focus reveal
- Footer: scroll-driven opacity fade

Sections closer to the top (About, Experience, Interests) keep whileInView for reliability since they lack scroll runway.