### PR TITLE
feat(i18n): add translation infrastructure with next-intl

### DIFF
--- a/__mocks__/next-intl.tsx
+++ b/__mocks__/next-intl.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import messages from "../messages/en.json";
+
+type Messages = Record<string, Record<string, string>>;
+
+export function useTranslations(namespace?: string) {
+  return (key: string, values?: Record<string, unknown>) => {
+    let text: string;
+    if (namespace) {
+      text = (messages as Messages)[namespace]?.[key] ?? `${namespace}.${key}`;
+    } else {
+      text = key;
+    }
+    if (values) {
+      return Object.entries(values).reduce(
+        (str, [k, v]) => str.replace(`{${k}}`, String(v)),
+        text,
+      );
+    }
+    return text;
+  };
+}
+
+export function useLocale() {
+  return "en";
+}
+
+export function useMessages() {
+  return messages;
+}
+
+export function NextIntlClientProvider({
+  children,
+}: {
+  children: React.ReactNode;
+  locale?: string;
+  messages?: Record<string, unknown>;
+}) {
+  return <>{children}</>;
+}

--- a/__tests__/components/language-switcher.test.tsx
+++ b/__tests__/components/language-switcher.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { LanguageSwitcher } from "../../components/language-switcher/language-switcher";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, locale, ...props }: any) => (
+    <a href={href} data-locale={locale} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+import { useRouter } from "next/router";
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe("LanguageSwitcher", () => {
+  it("renders nothing when only one locale is configured", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en"],
+      locale: "en",
+      asPath: "/",
+    } as any);
+
+    const { container } = render(<LanguageSwitcher />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders links for all locales when multiple are configured", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en", "es"],
+      locale: "en",
+      asPath: "/",
+    } as any);
+
+    render(<LanguageSwitcher />);
+    expect(screen.getByText("EN")).toBeInTheDocument();
+    expect(screen.getByText("ES")).toBeInTheDocument();
+  });
+
+  it("marks the current locale as active", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en", "es"],
+      locale: "en",
+      asPath: "/",
+    } as any);
+
+    render(<LanguageSwitcher />);
+    const enLink = screen.getByText("EN");
+    expect(enLink).toHaveAttribute("aria-current", "true");
+    const esLink = screen.getByText("ES");
+    expect(esLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("passes the current path to locale links", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en", "es"],
+      locale: "en",
+      asPath: "/blog/my-post",
+    } as any);
+
+    render(<LanguageSwitcher />);
+    const esLink = screen.getByText("ES");
+    expect(esLink.closest("a")).toHaveAttribute("data-locale", "es");
+  });
+});

--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import {
   Card as UICard,
   CardContent,
@@ -28,6 +29,7 @@ const BlogCard = ({
   tags,
   link,
 }: BlogCardProps) => {
+  const t = useTranslations("common");
   const tagsArray: string[] = tags
     ? Array.isArray(tags)
       ? (tags as unknown as string[])
@@ -80,7 +82,7 @@ const BlogCard = ({
         <CardFooter className="pt-0">
           <Button variant="default" size="default" className="w-full" asChild>
             <Link href={getLink(link)} target="_blank" rel="noopener noreferrer" className="no-underline">
-              Read more
+              {t("readMore")}
             </Link>
           </Button>
         </CardFooter>

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { Menu } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { ThemeSwitcher } from "@/components/theme-switcher/theme-switcher";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,6 +20,7 @@ export interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
+  const t = useTranslations("common");
   const getHref = (href: string) => {
     if (href.startsWith("/")) return href;
     return `/${href}`;
@@ -60,7 +62,7 @@ export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
           <Sheet>
             <SheetTrigger
               asChild
-              aria-label="Open navigation menu"
+              aria-label={t("openNav")}
               className="min-h-[44px] min-w-[44px] rounded-base border-2 border-border bg-main-foreground p-2.5 text-main shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
             >
               <button type="button">
@@ -69,7 +71,7 @@ export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
             </SheetTrigger>
             <SheetContent side="right" className="w-[min(100vw-2rem,320px)]">
               <SheetHeader>
-                <SheetTitle className="text-left">Menu</SheetTitle>
+                <SheetTitle className="text-left">{t("menu")}</SheetTitle>
               </SheetHeader>
               <ul className="mt-6 flex flex-col gap-2">
                 {navMap.length > 0 &&

--- a/components/language-switcher/language-switcher.tsx
+++ b/components/language-switcher/language-switcher.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+export const LanguageSwitcher = () => {
+  const { locales, locale: currentLocale, asPath } = useRouter();
+
+  if (!locales || locales.length <= 1) return null;
+
+  return (
+    <div className="flex gap-2">
+      {locales.map((locale) => (
+        <Link
+          key={locale}
+          href={asPath}
+          locale={locale}
+          aria-current={locale === currentLocale ? "true" : undefined}
+          className={`text-sm font-medium transition-colors ${
+            locale === currentLocale
+              ? "text-foreground underline"
+              : "text-foreground/60 hover:text-foreground"
+          }`}
+        >
+          {locale.toUpperCase()}
+        </Link>
+      ))}
+    </div>
+  );
+};

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslations } from "next-intl";
 import { Header } from "../header/header";
 import Footer from "../../sections/footer/footer";
 import Meta from "../meta/meta";
@@ -16,6 +17,7 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children, data, about }) => {
+  const t = useTranslations("common");
   const meta = data?.meta;
   const header = data?.header;
   const profiles = about?.profiles;
@@ -26,7 +28,7 @@ const Layout: React.FC<LayoutProps> = ({ children, data, about }) => {
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-[9999] focus:rounded-base focus:border-2 focus:border-border focus:bg-main focus:px-4 focus:py-2 focus:text-main-foreground focus:shadow-shadow"
       >
-        Skip to main content
+        {t("skipToMain")}
       </a>
       {meta && <Meta {...meta} />}
       {header && <Header {...header} />}

--- a/docs/superpowers/plans/2026-04-11-i18n-translations.md
+++ b/docs/superpowers/plans/2026-04-11-i18n-translations.md
@@ -1,0 +1,1026 @@
+# i18n Translations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add next-intl i18n infrastructure with subpath routing, extract all hardcoded UI strings into a translation file, and add a footer language switcher.
+
+**Architecture:** Next.js built-in i18n routing (`next.config.js` `i18n` object) + `next-intl` for translation management. Messages loaded per-locale in `getStaticProps`, served to components via `NextIntlClientProvider` and `useTranslations` hook. Language switcher in footer, hidden when only one locale is configured.
+
+**Tech Stack:** next-intl, Next.js Pages Router i18n routing
+
+**Spec:** `docs/superpowers/specs/2026-04-11-i18n-translations-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `messages/en.json` | Create | All UI strings organized by namespace |
+| `next.config.js` | Modify | Add `i18n` config object |
+| `pages/_app.tsx` | Modify | Wrap with `NextIntlClientProvider` |
+| `pages/index.tsx` | Modify | Load messages in `getStaticProps` |
+| `pages/blog/[link].tsx` | Modify | Load messages in `getStaticProps`, replace hardcoded strings |
+| `pages/photo-gallery/index.tsx` | Modify | Load messages in `getStaticProps` |
+| `pages/dev/index.tsx` | Modify | Load messages in `getStaticProps` |
+| `components/layout/Layout.tsx` | Modify | Replace "Skip to main content" with `useTranslations` |
+| `components/header/header.tsx` | Modify | Replace "Menu", aria-label with `useTranslations` |
+| `components/card/card.tsx` | Modify | Replace "Read more" with `useTranslations` |
+| `sections/banner/banner.tsx` | Modify | Replace "Hi, I'm" with `useTranslations` |
+| `sections/experience/experience.tsx` | Modify | Replace "Experience" heading with `useTranslations` |
+| `sections/interests/interests.tsx` | Modify | Replace CTA strings with `useTranslations` |
+| `sections/blog/blog.tsx` | Modify | Replace carousel aria-labels with `useTranslations` |
+| `sections/footer/footer.tsx` | Modify | Replace hardcoded strings, add `LanguageSwitcher` |
+| `components/language-switcher/language-switcher.tsx` | Create | Language switcher component |
+| `__tests__/components/language-switcher.test.tsx` | Create | Tests for language switcher |
+
+---
+
+### Task 1: Install next-intl and configure routing
+
+**Files:**
+- Modify: `package.json` (via npm install)
+- Modify: `next.config.js:1-22`
+
+- [ ] **Step 1: Install next-intl**
+
+Run: `npm install next-intl`
+
+- [ ] **Step 2: Add i18n config to next.config.js**
+
+In `next.config.js`, add the `i18n` property to the exported config object:
+
+```js
+const path = require("path");
+
+module.exports = {
+  i18n: {
+    locales: ["en"],
+    defaultLocale: "en",
+  },
+  sassOptions: {
+    includePaths: [path.join(__dirname, "styles")],
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.hashnode.com",
+      },
+    ],
+  },
+  compiler: {
+    emotion: false,
+  },
+};
+```
+
+- [ ] **Step 3: Verify dev server starts**
+
+Run: `npm run dev`
+Expected: Server starts without errors. Visit `http://localhost:3000` — page loads normally.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json next.config.js
+git commit -m "feat(i18n): install next-intl and configure i18n routing"
+```
+
+---
+
+### Task 2: Create translation file and wire up provider
+
+**Files:**
+- Create: `messages/en.json`
+- Modify: `pages/_app.tsx:1-31`
+
+- [ ] **Step 1: Create messages/en.json**
+
+```json
+{
+  "common": {
+    "readMore": "Read more",
+    "skipToMain": "Skip to main content",
+    "menu": "Menu",
+    "openNav": "Open navigation menu",
+    "comingSoon": "Coming Soon"
+  },
+  "banner": {
+    "greeting": "Hi, I'm"
+  },
+  "experience": {
+    "title": "Experience"
+  },
+  "interests": {
+    "viewBlog": "View My Blog Posts",
+    "viewGallery": "Explore Photo Gallery",
+    "viewGithub": "View My GitHub"
+  },
+  "blog": {
+    "sharePost": "Share this Post:",
+    "loading": "Loading blog post...",
+    "prevSlide": "Previous slide",
+    "nextSlide": "Next slide",
+    "goToSlide": "Go to slide {number}"
+  },
+  "footer": {
+    "thanks": "Thank you for stopping by!",
+    "getInTouch": "Let's get in touch on any of these platforms.",
+    "license": "License"
+  }
+}
+```
+
+- [ ] **Step 2: Wrap app with NextIntlClientProvider in _app.tsx**
+
+```tsx
+import "../styles/global.scss";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import * as gtag from "../lib/gtag";
+import { ThemeProvider } from "../lib/theme-context";
+import Layout from "../components/layout/Layout";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+export default function Portfolio({ Component, pageProps }) {
+  const router = useRouter();
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      if (isProduction) gtag.pageview(url);
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, [router.events]);
+
+  const { siteData, aboutData, messages, ...restPageProps } = pageProps;
+
+  return (
+    <NextIntlClientProvider locale={router.locale} messages={messages}>
+      <ThemeProvider>
+        <Layout data={siteData} about={aboutData}>
+          <Component {...restPageProps} aboutData={aboutData} />
+        </Layout>
+      </ThemeProvider>
+    </NextIntlClientProvider>
+  );
+}
+```
+
+- [ ] **Step 3: Verify dev server still runs**
+
+Run: `npm run dev`
+Expected: No errors. Page renders as before (messages not loaded yet — provider receives `undefined`, which is fine for now).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add messages/en.json pages/_app.tsx
+git commit -m "feat(i18n): create en.json messages and wire up NextIntlClientProvider"
+```
+
+---
+
+### Task 3: Load messages in all getStaticProps
+
+**Files:**
+- Modify: `pages/index.tsx:22-56` (getStaticProps)
+- Modify: `pages/blog/[link].tsx:8-49` (getStaticProps)
+- Modify: `pages/photo-gallery/index.tsx:4-45` (getStaticProps)
+- Modify: `pages/dev/index.tsx:5-31` (getStaticProps)
+
+- [ ] **Step 1: Update pages/index.tsx getStaticProps**
+
+Add `context` parameter and load messages. Change the function signature and add messages to props:
+
+```tsx
+export async function getStaticProps(context) {
+  const [siteDataRes, aboutRes, blogsRes] = await Promise.all([
+    fetch(`${process.env.BASE_URL}/site-datas/`),
+    fetch(`${process.env.BASE_URL}/abouts/`),
+    fetch(`${process.env.BASE_URL}/blogs`),
+  ]);
+
+  const [siteDataArray, aboutDataArray, blogsData] = await Promise.all([
+    siteDataRes.json(),
+    aboutRes.json(),
+    blogsRes.json() as Promise<tBlog[]>,
+  ]);
+
+  if (!siteDataArray || siteDataArray.length === 0 || !siteDataArray[0]) {
+    console.error("HomePage: Error fetching site data or siteData[0] is missing.");
+    return { notFound: true };
+  }
+  const site = siteDataArray[0];
+
+  if (!aboutDataArray || aboutDataArray.length === 0 || !aboutDataArray[0]) {
+    console.error("HomePage: Error fetching about data or aboutData[0] is missing.");
+    return { notFound: true };
+  }
+  const about = aboutDataArray[0];
+
+  return {
+    props: {
+      siteData: site,
+      aboutData: about,
+      bannerData: site.banner,
+      blogs: blogsData.map(toBlogCard),
+      messages: (await import(`../messages/${context.locale}.json`)).default,
+    },
+    revalidate: 3600,
+  };
+}
+```
+
+- [ ] **Step 2: Update pages/blog/[link].tsx getStaticProps**
+
+Add messages to the props return:
+
+```tsx
+export async function getStaticProps(context) {
+    const siteDataRes = await fetch(`${process.env.BASE_URL}/site-datas/`);
+    const siteDataArray = await siteDataRes.json();
+
+    const aboutRes = await fetch(`${process.env.BASE_URL}/abouts/`);
+    const aboutDataArray = await aboutRes.json();
+
+    let blogPostData = {};
+    if (context.params.link && !context.params.link.startsWith("http")) {
+        const blogPostRes = await fetch(`${process.env.BASE_URL}/blogs/${context.params.link}`);
+        blogPostData = await blogPostRes.json();
+        if (Object.keys(blogPostData).length === 0) {
+             console.error(`Blog [${context.params.link}]: Blog post not found or empty.`);
+            return { notFound: true };
+        }
+    } else {
+        return { notFound: true };
+    }
+
+    if (!siteDataArray || siteDataArray.length === 0 || !siteDataArray[0]) {
+        console.error(`Blog [${context.params.link}]: Error fetching site data.`);
+        return { notFound: true };
+    }
+    const site = siteDataArray[0];
+
+    if (!aboutDataArray || aboutDataArray.length === 0 || !aboutDataArray[0]) {
+        console.error(`Blog [${context.params.link}]: Error fetching about data.`);
+        return { notFound: true };
+    }
+    const about = aboutDataArray[0];
+
+    return {
+        props: {
+            siteData: site,
+            aboutData: about,
+            blogPost: blogPostData,
+            messages: (await import(`../../messages/${context.locale}.json`)).default,
+        },
+        revalidate: 3600,
+    };
+}
+```
+
+- [ ] **Step 3: Update pages/photo-gallery/index.tsx getStaticProps**
+
+Add `context` parameter and messages to props:
+
+```tsx
+export async function getStaticProps(context) {
+  const siteDataRes = await fetch(`${process.env.BASE_URL}/site-datas/`);
+  const siteDataArray = await siteDataRes.json();
+
+  const aboutRes = await fetch(`${process.env.BASE_URL}/abouts/`);
+  const aboutDataArray = await aboutRes.json();
+
+  const photoGalleriesRes = await fetch(`${process.env.BASE_URL}/photo-galleries/`);
+  const photoGalleries = await photoGalleriesRes.json();
+  const galleryItems = photoGalleries.flatMap((gallery) =>
+    (gallery.images || []).map((img, idx) => ({
+      id: `${gallery.title}-${idx}`,
+      src: img.src,
+      thumb: img.src,
+      caption: img.caption,
+      category: gallery.title,
+      location: gallery.location,
+    })),
+  );
+
+  if (!siteDataArray || siteDataArray.length === 0 || !siteDataArray[0]) {
+    console.error("PhotoGalleryPage: Error fetching site data.");
+    return { notFound: true };
+  }
+  const site = siteDataArray[0];
+
+  if (!aboutDataArray || aboutDataArray.length === 0 || !aboutDataArray[0]) {
+    console.error("PhotoGalleryPage: Error fetching about data.");
+    return { notFound: true };
+  }
+  const about = aboutDataArray[0];
+
+  return {
+    props: {
+      siteData: site,
+      aboutData: about,
+      galleryItems,
+      messages: (await import(`../../messages/${context.locale}.json`)).default,
+    },
+    revalidate: 3600,
+  };
+}
+```
+
+- [ ] **Step 4: Update pages/dev/index.tsx getStaticProps**
+
+Add `context` parameter and messages to props:
+
+```tsx
+export const getStaticProps: GetStaticProps = async (context) => {
+  const siteDataRes = await fetch(`${process.env.BASE_URL}/site-datas/`);
+  const siteDataArray = await siteDataRes.json();
+
+  const aboutRes = await fetch(`${process.env.BASE_URL}/abouts/`);
+  const aboutDataArray = await aboutRes.json();
+
+  if (!siteDataArray || siteDataArray.length === 0 || !siteDataArray[0]) {
+    console.error("DevPage: Error fetching site data.");
+    return { notFound: true };
+  }
+  const site = siteDataArray[0];
+
+  if (!aboutDataArray || aboutDataArray.length === 0 || !aboutDataArray[0]) {
+    console.error("DevPage: Error fetching about data.");
+    return { notFound: true };
+  }
+  const about = aboutDataArray[0];
+
+  return {
+    props: {
+      siteData: site,
+      aboutData: about,
+      messages: (await import(`../../messages/${context.locale}.json`)).default,
+    },
+    revalidate: 3600,
+  };
+};
+```
+
+- [ ] **Step 5: Verify the build passes**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: No type errors, build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pages/index.tsx pages/blog/[link].tsx pages/photo-gallery/index.tsx pages/dev/index.tsx
+git commit -m "feat(i18n): load locale messages in all getStaticProps"
+```
+
+---
+
+### Task 4: Replace hardcoded strings in layout, header, and card
+
+**Files:**
+- Modify: `components/layout/Layout.tsx:1-39`
+- Modify: `components/header/header.tsx:1-98`
+- Modify: `components/card/card.tsx:1-92`
+
+- [ ] **Step 1: Update Layout.tsx — replace "Skip to main content"**
+
+```tsx
+import React from "react";
+import { useTranslations } from "next-intl";
+import { Header } from "../header/header";
+import Footer from "../../sections/footer/footer";
+import Meta from "../meta/meta";
+import { SmoothScroll } from "../smooth-scroll";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  data: {
+    meta?: any;
+    header?: any;
+  };
+  about: {
+    profiles?: any[];
+  };
+}
+
+const Layout: React.FC<LayoutProps> = ({ children, data, about }) => {
+  const t = useTranslations("common");
+  const meta = data?.meta;
+  const header = data?.header;
+  const profiles = about?.profiles;
+
+  return (
+    <SmoothScroll>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-[9999] focus:rounded-base focus:border-2 focus:border-border focus:bg-main focus:px-4 focus:py-2 focus:text-main-foreground focus:shadow-shadow"
+      >
+        {t("skipToMain")}
+      </a>
+      {meta && <Meta {...meta} />}
+      {header && <Header {...header} />}
+      <main id="main-content">{children}</main>
+      {profiles && <Footer profiles={profiles} />}
+    </SmoothScroll>
+  );
+};
+
+export default Layout;
+```
+
+- [ ] **Step 2: Update header.tsx — replace "Menu" and aria-label**
+
+Add `useTranslations` import and hook call at the top of the component. Replace two strings:
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { Menu } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { ThemeSwitcher } from "@/components/theme-switcher/theme-switcher";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+export interface HeaderProps {
+  logoUrl: string;
+  navMap?: Array<{ href: string; label: string }>;
+}
+
+export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
+  const t = useTranslations("common");
+
+  const getHref = (href: string) => {
+    if (href.startsWith("/")) return href;
+    return `/${href}`;
+  };
+
+  const navLinks = (
+    <>
+      {navMap.length > 0 &&
+        navMap.map((item) => (
+          <Button key={item.href} variant="neutral" size="default" asChild>
+            <Link href={getHref(item.href)} className="no-underline">
+              {item.label}
+            </Link>
+          </Button>
+        ))}
+    </>
+  );
+
+  return (
+    <header className="sticky top-0 z-40 w-full border-b-2 border-border bg-main py-4 shadow-shadow md:py-6">
+      <div className="container flex justify-between items-center">
+        <Link href="/" className="flex-shrink-0">
+          <Image
+            height={56}
+            width={250}
+            src={logoUrl}
+            alt="Logo"
+            priority
+            className="h-10 w-auto md:h-14"
+          />
+        </Link>
+
+        <nav className="hidden lg:flex lg:items-center gap-2">
+          {navLinks}
+          <ThemeSwitcher />
+        </nav>
+
+        <div className="flex lg:hidden">
+          <Sheet>
+            <SheetTrigger
+              asChild
+              aria-label={t("openNav")}
+              className="min-h-[44px] min-w-[44px] rounded-base border-2 border-border bg-main-foreground p-2.5 text-main shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
+            >
+              <button type="button">
+                <Menu className="size-6" />
+              </button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-[min(100vw-2rem,320px)]">
+              <SheetHeader>
+                <SheetTitle className="text-left">{t("menu")}</SheetTitle>
+              </SheetHeader>
+              <ul className="mt-6 flex flex-col gap-2">
+                {navMap.length > 0 &&
+                  navMap.map((item) => (
+                    <li key={item.href}>
+                      <Button
+                        variant="neutral"
+                        size="default"
+                        className="w-full justify-start text-left"
+                        asChild
+                      >
+                        <Link href={getHref(item.href)}>{item.label}</Link>
+                      </Button>
+                    </li>
+                  ))}
+              </ul>
+              <div className="mt-4">
+                <ThemeSwitcher />
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
+      </div>
+    </header>
+  );
+};
+```
+
+- [ ] **Step 3: Update card.tsx — replace "Read more"**
+
+Add `useTranslations` import and hook call. Replace the button text:
+
+Change in `card.tsx`:
+- Add `import { useTranslations } from "next-intl";` after the framer-motion import
+- Add `const t = useTranslations("common");` as the first line inside the `Card` component function
+- Replace `Read more` with `{t("readMore")}`
+
+The CardFooter becomes:
+```tsx
+<CardFooter className="pt-0">
+  <Button variant="default" size="default" className="w-full" asChild>
+    <Link href={getLink(link)} target="_blank" rel="noopener noreferrer" className="no-underline">
+      {t("readMore")}
+    </Link>
+  </Button>
+</CardFooter>
+```
+
+- [ ] **Step 4: Verify types pass**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/layout/Layout.tsx components/header/header.tsx components/card/card.tsx
+git commit -m "feat(i18n): replace hardcoded strings in layout, header, and card"
+```
+
+---
+
+### Task 5: Replace hardcoded strings in banner, experience, and interests
+
+**Files:**
+- Modify: `sections/banner/banner.tsx:136-141`
+- Modify: `sections/experience/experience.tsx:29-30`
+- Modify: `sections/interests/interests.tsx:53-92`
+
+- [ ] **Step 1: Update banner.tsx — replace "Hi, I'm"**
+
+Add `import { useTranslations } from "next-intl";` after the existing imports.
+Add `const t = useTranslations("banner");` as the first line inside the `Banner` component (before `timeoutRef`).
+
+Replace the h1 content (lines 137-154). The `aria-label` and visible text both change:
+
+```tsx
+<h1
+  className="text-2xl font-bold leading-tight text-foreground md:text-4xl lg:text-5xl"
+  aria-label={`${t("greeting")} ${texts[0]}`}
+>
+  {t("greeting")}{" "}
+  <span className="relative inline-block" aria-hidden="true">
+    <span
+      className="relative z-10 inline-block border-2 border-border bg-main px-2 py-0.5 text-main-foreground shadow-shadow md:px-3 md:py-1"
+      style={{ boxShadow: "2px 2px 0px 0px #000000" }}
+    >
+      <span
+        id="typewrite"
+        className="text-main-foreground"
+        data-period="2000"
+        data-type={JSON.stringify(texts)}
+      />
+    </span>
+  </span>
+</h1>
+```
+
+- [ ] **Step 2: Update experience.tsx — replace "Experience" heading**
+
+Add `import { useTranslations } from "next-intl";` after the existing imports.
+Add `const t = useTranslations("experience");` inside the `Experience` component.
+
+Replace the Section heading prop:
+
+```tsx
+<Section container id="experience" heading={t("title")}>
+```
+
+- [ ] **Step 3: Update interests.tsx — replace CTA strings**
+
+Add `import { useTranslations } from "next-intl";` after the existing imports.
+Add `const t = useTranslations("interests");` inside the `Interests` component (before `getInterestType`).
+Also add `const tc = useTranslations("common");` for the "Coming Soon" string.
+
+Replace the `getCTA` function body:
+
+```tsx
+const getCTA = (interest: { title: string; description: string }) => {
+  const type = getInterestType(interest.title);
+  switch (type) {
+    case "blogging":
+      return (
+        <Button variant="default" size="default" asChild>
+          <Link href="/blog" className="no-underline">
+            {t("viewBlog")}
+          </Link>
+        </Button>
+      );
+    case "photography":
+      return (
+        <Button variant="default" size="default" asChild>
+          <Link href="/photo-gallery" className="no-underline">
+            {t("viewGallery")}
+          </Link>
+        </Button>
+      );
+    case "coding":
+      return (
+        <Button variant="default" size="default" asChild>
+          <Link
+            href="https://github.com/ps011"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="no-underline"
+          >
+            {t("viewGithub")}
+          </Link>
+        </Button>
+      );
+    default:
+      return (
+        <Button variant="neutral" size="default" disabled>
+          {tc("comingSoon")}
+        </Button>
+      );
+  }
+};
+```
+
+- [ ] **Step 4: Verify types pass**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sections/banner/banner.tsx sections/experience/experience.tsx sections/interests/interests.tsx
+git commit -m "feat(i18n): replace hardcoded strings in banner, experience, and interests"
+```
+
+---
+
+### Task 6: Replace hardcoded strings in blog section, blog page, and footer
+
+**Files:**
+- Modify: `sections/blog/blog.tsx:80-110`
+- Modify: `pages/blog/[link].tsx:75-119`
+- Modify: `sections/footer/footer.tsx:36-75`
+
+- [ ] **Step 1: Update blog.tsx — replace carousel aria-labels**
+
+Add `import { useTranslations } from "next-intl";` after the existing imports.
+Add `const t = useTranslations("blog");` inside the `BlogCarousel` component (before the state declarations).
+
+Replace three aria-labels in the carousel controls:
+
+```tsx
+<Button
+  variant="noShadow"
+  size="icon"
+  onClick={() => api?.scrollPrev()}
+  disabled={!canScrollPrev}
+  aria-label={t("prevSlide")}
+  className="h-9 w-9 shrink-0 rounded-base border-2 border-border disabled:opacity-40"
+>
+  <ArrowLeft className="size-4" />
+</Button>
+```
+
+```tsx
+<button
+  key={i}
+  onClick={() => api?.scrollTo(i)}
+  aria-label={t("goToSlide", { number: i + 1 })}
+  className={cn(
+    "h-2.5 rounded-full border-2 border-border shadow-[1px_1px_0px_0px_#000000] transition-all duration-200",
+    i === current ? "w-6 bg-main" : "w-2.5 bg-secondary-background",
+  )}
+/>
+```
+
+```tsx
+<Button
+  variant="noShadow"
+  size="icon"
+  onClick={() => api?.scrollNext()}
+  disabled={!canScrollNext}
+  aria-label={t("nextSlide")}
+  className="h-9 w-9 shrink-0 rounded-base border-2 border-border disabled:opacity-40"
+>
+  <ArrowRight className="size-4" />
+</Button>
+```
+
+- [ ] **Step 2: Update pages/blog/[link].tsx — replace "Share this Post:" and loading text**
+
+Add `import { useTranslations } from "next-intl";` after the existing imports.
+Add `const t = useTranslations("blog");` inside the `SingleBlogPage` component (after `const router = useRouter();`).
+
+Replace the loading text:
+```tsx
+if (!blogPost || Object.keys(blogPost).length === 0) {
+    return <p>{t("loading")}</p>;
+}
+```
+
+Replace "Share this Post:":
+```tsx
+<span className="text-neutralGray-900 dark:text-white">{t("sharePost")}</span>
+```
+
+- [ ] **Step 3: Update footer.tsx — replace hardcoded strings**
+
+Add `import { useTranslations } from "next-intl";` after the existing imports.
+Add `const t = useTranslations("footer");` inside the `Footer` component (after `const prefersReduced = ...`).
+
+Replace three strings:
+
+```tsx
+<h3 className="mb-2 text-2xl font-bold text-foreground">
+  {t("thanks")}
+</h3>
+<p className="mb-4 text-foreground md:mb-0">
+  {t("getInTouch")}
+</p>
+```
+
+```tsx
+<a
+  href="https://github.com/ps011/ps11/LICENSE.md"
+  target="_blank"
+  rel="noreferrer"
+  className="underline hover:no-underline"
+>
+  {t("license")}
+</a>
+```
+
+- [ ] **Step 4: Verify types pass**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sections/blog/blog.tsx pages/blog/[link].tsx sections/footer/footer.tsx
+git commit -m "feat(i18n): replace hardcoded strings in blog section, blog page, and footer"
+```
+
+---
+
+### Task 7: Create LanguageSwitcher component with tests
+
+**Files:**
+- Create: `components/language-switcher/language-switcher.tsx`
+- Create: `__tests__/components/language-switcher.test.tsx`
+- Modify: `sections/footer/footer.tsx` (add LanguageSwitcher)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/components/language-switcher.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { LanguageSwitcher } from "../../components/language-switcher/language-switcher";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, locale, ...props }: any) => (
+    <a href={href} data-locale={locale} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+import { useRouter } from "next/router";
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe("LanguageSwitcher", () => {
+  it("renders nothing when only one locale is configured", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en"],
+      locale: "en",
+      asPath: "/",
+    } as any);
+
+    const { container } = render(<LanguageSwitcher />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders links for all locales when multiple are configured", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en", "es"],
+      locale: "en",
+      asPath: "/",
+    } as any);
+
+    render(<LanguageSwitcher />);
+    expect(screen.getByText("EN")).toBeInTheDocument();
+    expect(screen.getByText("ES")).toBeInTheDocument();
+  });
+
+  it("marks the current locale as active", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en", "es"],
+      locale: "en",
+      asPath: "/",
+    } as any);
+
+    render(<LanguageSwitcher />);
+    const enLink = screen.getByText("EN");
+    expect(enLink).toHaveAttribute("aria-current", "true");
+    const esLink = screen.getByText("ES");
+    expect(esLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("passes the current path to locale links", () => {
+    mockUseRouter.mockReturnValue({
+      locales: ["en", "es"],
+      locale: "en",
+      asPath: "/blog/my-post",
+    } as any);
+
+    render(<LanguageSwitcher />);
+    const esLink = screen.getByText("ES");
+    expect(esLink.closest("a")).toHaveAttribute("data-locale", "es");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/components/language-switcher.test.tsx --no-coverage`
+Expected: FAIL — Cannot find module `../../components/language-switcher/language-switcher`
+
+- [ ] **Step 3: Create the LanguageSwitcher component**
+
+Create `components/language-switcher/language-switcher.tsx`:
+
+```tsx
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+export const LanguageSwitcher = () => {
+  const { locales, locale: currentLocale, asPath } = useRouter();
+
+  if (!locales || locales.length <= 1) return null;
+
+  return (
+    <div className="flex gap-2">
+      {locales.map((locale) => (
+        <Link
+          key={locale}
+          href={asPath}
+          locale={locale}
+          aria-current={locale === currentLocale ? "true" : undefined}
+          className={`text-sm font-medium transition-colors ${
+            locale === currentLocale
+              ? "text-foreground underline"
+              : "text-foreground/60 hover:text-foreground"
+          }`}
+        >
+          {locale.toUpperCase()}
+        </Link>
+      ))}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/components/language-switcher.test.tsx --no-coverage`
+Expected: PASS — all 4 tests pass.
+
+- [ ] **Step 5: Add LanguageSwitcher to footer**
+
+In `sections/footer/footer.tsx`, add import and render the switcher in the bottom bar:
+
+Add import:
+```tsx
+import { LanguageSwitcher } from "../../components/language-switcher/language-switcher";
+```
+
+Replace the bottom `<div>` (the one with copyright and license) to include the switcher:
+
+```tsx
+<div className="flex flex-col gap-2 text-sm text-foreground sm:flex-row sm:justify-between sm:items-center">
+  <span>
+    &copy; {new Date().getFullYear()}{" "}
+    <a
+      href="https://linkedin.com/in/ps011"
+      target="_blank"
+      rel="noreferrer"
+      className="underline hover:no-underline"
+    >
+      Prasheel
+    </a>
+  </span>
+  <div className="flex items-center gap-4">
+    <LanguageSwitcher />
+    <a
+      href="https://github.com/ps011/ps11/LICENSE.md"
+      target="_blank"
+      rel="noreferrer"
+      className="underline hover:no-underline"
+    >
+      {t("license")}
+    </a>
+  </div>
+</div>
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `npm test -- --no-coverage`
+Expected: All tests pass.
+
+- [ ] **Step 7: Verify dev server and visual check**
+
+Run: `npm run dev`
+Expected: Site loads normally. No language switcher visible (only 1 locale configured). All text displays correctly from translations.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add components/language-switcher/language-switcher.tsx __tests__/components/language-switcher.test.tsx sections/footer/footer.tsx
+git commit -m "feat(i18n): add LanguageSwitcher component in footer"
+```
+
+---
+
+### Task 8: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run lint**
+
+Run: `npm run lint`
+Expected: No errors.
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test -- --no-coverage`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: Build succeeds. Check that all pages are generated.
+
+- [ ] **Step 5: Visual verification**
+
+Run: `npm run dev`
+Verify:
+- Home page loads, all text displays correctly
+- "Hi, I'm" text works with typewriter animation
+- "Experience" heading shows
+- Interest CTAs show correct text
+- Footer shows "Thank you for stopping by!" and "License"
+- Blog carousel aria-labels work (inspect in devtools)
+- Navigate to a blog post — "Share this Post:" displays
+- No language switcher visible (correct — only 1 locale)

--- a/docs/superpowers/specs/2026-04-11-i18n-translations-design.md
+++ b/docs/superpowers/specs/2026-04-11-i18n-translations-design.md
@@ -1,0 +1,204 @@
+# i18n / Translations Design Spec
+
+## Overview
+
+Add internationalization support to the portfolio using **next-intl** with **Next.js subpath routing**. Phase 1 focuses on extracting hardcoded UI strings and wiring up the translation infrastructure. The site starts with English only; adding a language later requires one config entry and one JSON file.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Library | next-intl | Battle-tested, Pages Router support, interpolation/pluralization built in |
+| Routing | Subpath (`/en/`, `/es/`) | SEO-friendly, built into Next.js Pages Router |
+| File structure | One JSON per language (`messages/en.json`) | Simple, easy to hand off to translators |
+| Language switcher | Footer | Low-profile, appropriate for a portfolio |
+| Scope | UI strings only (Phase 1) | CMS content migrates later |
+
+## Architecture
+
+### Routing
+
+Next.js built-in i18n routing via `next.config.js`:
+
+```js
+i18n: {
+  locales: ["en"],
+  defaultLocale: "en",
+}
+```
+
+- `/` serves the default locale (English)
+- Adding `"es"` to `locales` array automatically creates `/es/`, `/es/blog/my-post`, etc.
+- `context.locale` available in `getStaticProps`
+- `router.locale` available on the client
+
+### Provider Setup
+
+`_app.tsx` wraps the app with `NextIntlClientProvider`:
+
+```tsx
+import { NextIntlClientProvider } from "next-intl";
+import { useRouter } from "next/router";
+
+// Inside App component:
+const router = useRouter();
+
+<NextIntlClientProvider locale={router.locale} messages={pageProps.messages}>
+  {/* existing providers (UIConfigProvider, ThemeProvider, etc.) */}
+</NextIntlClientProvider>
+```
+
+### Message Loading
+
+Every page's `getStaticProps` loads the locale's messages:
+
+```tsx
+export async function getStaticProps(context) {
+  const messages = (await import(`../messages/${context.locale}.json`)).default;
+  return {
+    props: {
+      // ...existing props
+      messages,
+    },
+  };
+}
+```
+
+### Translation File
+
+`messages/en.json` — flat file with namespaced keys:
+
+```json
+{
+  "common": {
+    "readMore": "Read more",
+    "skipToMain": "Skip to main content",
+    "menu": "Menu",
+    "openNav": "Open navigation menu",
+    "comingSoon": "Coming Soon"
+  },
+  "banner": {
+    "greeting": "Hi, I'm"
+  },
+  "experience": {
+    "title": "Experience"
+  },
+  "interests": {
+    "viewBlog": "View My Blog Posts",
+    "viewGallery": "Explore Photo Gallery",
+    "viewGithub": "View My GitHub"
+  },
+  "blog": {
+    "sharePost": "Share this Post:",
+    "loading": "Loading blog post...",
+    "prevSlide": "Previous slide",
+    "nextSlide": "Next slide"
+  },
+  "footer": {
+    "thanks": "Thank you for stopping by!",
+    "getInTouch": "Let's get in touch on any of these platforms.",
+    "license": "License"
+  }
+}
+```
+
+Components access strings via namespace:
+
+```tsx
+import { useTranslations } from "next-intl";
+
+function Footer() {
+  const t = useTranslations("footer");
+  return <p>{t("thanks")}</p>;
+}
+```
+
+### Language Switcher
+
+A component in the footer that renders links for each available locale:
+
+```tsx
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+function LanguageSwitcher() {
+  const router = useRouter();
+  const { locales, locale: currentLocale, asPath } = router;
+
+  // Don't render if only one locale is configured
+  if (!locales || locales.length <= 1) return null;
+
+  return (
+    <div>
+      {locales.map((locale) => (
+        <Link key={locale} href={asPath} locale={locale}>
+          {locale.toUpperCase()}
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+The switcher is invisible with a single locale and appears automatically when a second locale is added.
+
+## Components to Update
+
+These components have hardcoded strings that need extraction:
+
+| Component | Strings to extract |
+|-----------|-------------------|
+| `components/layout/Layout.tsx` | "Skip to main content" |
+| `components/header/header.tsx` | "Menu", "Open navigation menu" |
+| `components/card/card.tsx` | "Read more" |
+| `sections/banner/banner.tsx` | "Hi, I'm" |
+| `sections/experience/experience.tsx` | "Experience" heading |
+| `sections/interests/interests.tsx` | CTA button texts ("View My Blog Posts", etc.), "Coming Soon" |
+| `sections/blog/blog.tsx` | Carousel control labels |
+| `sections/footer/footer.tsx` | "Thank you for stopping by!", "Let's get in touch...", "License" |
+| `pages/blog/[link].tsx` | "Share this Post:", "Loading blog post..." |
+
+## Pages Requiring getStaticProps Changes
+
+| Page | Change |
+|------|--------|
+| `pages/index.tsx` | Add `messages` to props |
+| `pages/blog/[link].tsx` | Add `messages` to props |
+| `pages/photo-gallery/index.tsx` | Add `messages` to props |
+| `pages/dev/index.tsx` | Add `messages` to props (if it has translatable strings) |
+
+## What Does NOT Change
+
+- Theme system (independent of locale)
+- Lenis smooth scroll / Framer Motion animations
+- Blog markdown rendering (content stays in authored language)
+- Photo gallery, map section data
+- Data fetching from CMS (untouched in Phase 1)
+- UIConfig system (coexists with translations; UIConfig handles layout/behavior, translations handle text)
+
+## Phasing
+
+### Phase 1: Foundation (this work)
+- Install `next-intl`
+- Configure `next.config.js` with `i18n` object
+- Set up `NextIntlClientProvider` in `_app.tsx`
+- Create `messages/en.json` with all extracted UI strings
+- Update `getStaticProps` on all pages to load messages
+- Replace hardcoded strings in all components with `useTranslations`
+- Add `LanguageSwitcher` component in footer (hidden when single locale)
+
+### Phase 2: Add a second language (future)
+- Add locale to `next.config.js` (e.g., `locales: ["en", "es"]`)
+- Create `messages/es.json` with translated strings
+- Language switcher becomes visible
+
+### Phase 3: CMS content migration (future)
+- Move CMS data to locale-aware local JSON (`data/en/site.json`, `data/es/site.json`)
+- Update `lib/data.ts` to accept a `locale` parameter
+- Pass `context.locale` from `getStaticProps` into data-fetching functions
+
+## Testing
+
+- Existing tests should continue passing (English strings don't change, just their source)
+- Add a test for the `LanguageSwitcher` component (renders nothing with one locale, renders links with multiple)
+- Verify `getStaticProps` correctly loads messages for the locale

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,8 +6,10 @@ const createJestConfig = nextJest({ dir: "./" });
 const config: Config = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testEnvironment: "jest-environment-jsdom",
+  testPathIgnorePatterns: ["/node_modules/", "/.worktrees/"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
+    "^next-intl$": "<rootDir>/__mocks__/next-intl.tsx",
   },
   collectCoverageFrom: [
     "components/**/*.{ts,tsx}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,32 @@
+{
+  "common": {
+    "readMore": "Read more",
+    "skipToMain": "Skip to main content",
+    "menu": "Menu",
+    "openNav": "Open navigation menu",
+    "comingSoon": "Coming Soon"
+  },
+  "banner": {
+    "greeting": "Hi, I'm"
+  },
+  "experience": {
+    "title": "Experience"
+  },
+  "interests": {
+    "viewBlog": "View My Blog Posts",
+    "viewGallery": "Explore Photo Gallery",
+    "viewGithub": "View My GitHub"
+  },
+  "blog": {
+    "sharePost": "Share this Post:",
+    "loading": "Loading blog post...",
+    "prevSlide": "Previous slide",
+    "nextSlide": "Next slide",
+    "goToSlide": "Go to slide {number}"
+  },
+  "footer": {
+    "thanks": "Thank you for stopping by!",
+    "getInTouch": "Let's get in touch on any of these platforms.",
+    "license": "License"
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 const path = require("path");
 
 module.exports = {
+  i18n: {
+    locales: ["en"],
+    defaultLocale: "en",
+  },
   sassOptions: {
     includePaths: [path.join(__dirname, "styles")],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lenis": "^1.3.17",
         "lucide-react": "^0.564.0",
         "next": "^16.1.6",
+        "next-intl": "^4.9.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-github-calendar": "^5.0.5",
@@ -1663,6 +1664,57 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/bigdecimal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.0.tgz",
+      "integrity": "sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.2.0.tgz",
+      "integrity": "sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/bigdecimal": "0.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/intl-localematcher": "0.8.2"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.1.tgz",
+      "integrity": "sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.3.tgz",
+      "integrity": "sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/icu-skeleton-parser": "2.1.3"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.3.tgz",
+      "integrity": "sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.2.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.2.tgz",
+      "integrity": "sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.1"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3384,6 +3436,313 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3983,6 +4342,12 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "license": "MIT"
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -4010,6 +4375,244 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.24.tgz",
+      "integrity": "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.24",
+        "@swc/core-darwin-x64": "1.15.24",
+        "@swc/core-linux-arm-gnueabihf": "1.15.24",
+        "@swc/core-linux-arm64-gnu": "1.15.24",
+        "@swc/core-linux-arm64-musl": "1.15.24",
+        "@swc/core-linux-ppc64-gnu": "1.15.24",
+        "@swc/core-linux-s390x-gnu": "1.15.24",
+        "@swc/core-linux-x64-gnu": "1.15.24",
+        "@swc/core-linux-x64-musl": "1.15.24",
+        "@swc/core-win32-arm64-msvc": "1.15.24",
+        "@swc/core-win32-ia32-msvc": "1.15.24",
+        "@swc/core-win32-x64-msvc": "1.15.24"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.24.tgz",
+      "integrity": "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.24.tgz",
+      "integrity": "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.24.tgz",
+      "integrity": "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.24.tgz",
+      "integrity": "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.24.tgz",
+      "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.24.tgz",
+      "integrity": "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.24.tgz",
+      "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.24.tgz",
+      "integrity": "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.24.tgz",
+      "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.24.tgz",
+      "integrity": "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.24.tgz",
+      "integrity": "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.24.tgz",
+      "integrity": "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -4017,6 +4620,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tabler/icons": {
@@ -6883,7 +7495,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
       "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9409,6 +10020,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.9.1.tgz",
+      "integrity": "sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "dev": true,
@@ -9644,6 +10270,17 @@
     "node_modules/internmap": {
       "version": "1.0.1",
       "license": "ISC"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.0.tgz",
+      "integrity": "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/icu-messageformat-parser": "3.5.3"
+      }
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -14051,6 +14688,15 @@
       "version": "1.4.0",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
@@ -14109,6 +14755,43 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.9.1.tgz",
+      "integrity": "sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.9.1",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.9.1",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.9.1"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
+      "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w==",
+      "license": "MIT"
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -14135,6 +14818,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -14687,6 +15376,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -17557,6 +18252,27 @@
         }
       }
     },
+    "node_modules/use-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.9.1.tgz",
+      "integrity": "sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.9.1",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
@@ -19206,6 +19922,51 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
+    "@formatjs/bigdecimal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.0.tgz",
+      "integrity": "sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w=="
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.2.0.tgz",
+      "integrity": "sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==",
+      "requires": {
+        "@formatjs/bigdecimal": "0.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/intl-localematcher": "0.8.2"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.1.tgz",
+      "integrity": "sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg=="
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.3.tgz",
+      "integrity": "sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/icu-skeleton-parser": "2.1.3"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.3.tgz",
+      "integrity": "sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "3.2.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.2.tgz",
+      "integrity": "sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==",
+      "requires": {
+        "@formatjs/fast-memoize": "3.1.1"
+      }
+    },
     "@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -20228,6 +20989,115 @@
         "fastq": "^1.6.0"
       }
     },
+    "@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "requires": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6",
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
+        }
+      }
+    },
+    "@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "optional": true
+    },
+    "@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "optional": true
+    },
+    "@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "optional": true
+    },
+    "@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "optional": true
+    },
+    "@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "optional": true
+    },
+    "@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "optional": true
+    },
+    "@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "optional": true
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -20498,6 +21368,11 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="
     },
+    "@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="
+    },
     "@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -20522,12 +21397,118 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "@swc/core": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.24.tgz",
+      "integrity": "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ==",
+      "requires": {
+        "@swc/core-darwin-arm64": "1.15.24",
+        "@swc/core-darwin-x64": "1.15.24",
+        "@swc/core-linux-arm-gnueabihf": "1.15.24",
+        "@swc/core-linux-arm64-gnu": "1.15.24",
+        "@swc/core-linux-arm64-musl": "1.15.24",
+        "@swc/core-linux-ppc64-gnu": "1.15.24",
+        "@swc/core-linux-s390x-gnu": "1.15.24",
+        "@swc/core-linux-x64-gnu": "1.15.24",
+        "@swc/core-linux-x64-musl": "1.15.24",
+        "@swc/core-win32-arm64-msvc": "1.15.24",
+        "@swc/core-win32-ia32-msvc": "1.15.24",
+        "@swc/core-win32-x64-msvc": "1.15.24",
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.24.tgz",
+      "integrity": "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g==",
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.24.tgz",
+      "integrity": "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg==",
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.24.tgz",
+      "integrity": "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.24.tgz",
+      "integrity": "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.24.tgz",
+      "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
+      "optional": true
+    },
+    "@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.24.tgz",
+      "integrity": "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ==",
+      "optional": true
+    },
+    "@swc/core-linux-s390x-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.24.tgz",
+      "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.24.tgz",
+      "integrity": "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.24.tgz",
+      "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.24.tgz",
+      "integrity": "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA==",
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.24.tgz",
+      "integrity": "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ==",
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.15.24",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.24.tgz",
+      "integrity": "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ==",
+      "optional": true
+    },
+    "@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+    },
     "@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "requires": {
         "tslib": "^2.8.0"
+      }
+    },
+    "@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "requires": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "@tabler/icons": {
@@ -22362,8 +23343,7 @@
     "detect-libc": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
-      "optional": true
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -24048,6 +25028,14 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icu-minify": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.9.1.tgz",
+      "integrity": "sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==",
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "dev": true
@@ -24192,6 +25180,16 @@
     },
     "internmap": {
       "version": "1.0.1"
+    },
+    "intl-messageformat": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.0.tgz",
+      "integrity": "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/icu-messageformat-parser": "3.5.3"
+      }
     },
     "is-array-buffer": {
       "version": "3.0.5",
@@ -27068,6 +28066,11 @@
     "natural-compare": {
       "version": "1.4.0"
     },
+    "negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
     "neo-async": {
       "version": "2.6.2",
       "dev": true
@@ -27105,6 +28108,31 @@
           }
         }
       }
+    },
+    "next-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.9.1.tgz",
+      "integrity": "sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==",
+      "requires": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.9.1",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.9.1",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.9.1"
+      }
+    },
+    "next-intl-swc-plugin-extractor": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
+      "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w=="
+    },
+    "node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -27452,6 +28480,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ=="
     },
     "possible-typed-array-names": {
       "version": "1.1.0",
@@ -29292,6 +30325,17 @@
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "requires": {
         "tslib": "^2.0.0"
+      }
+    },
+    "use-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.9.1.tgz",
+      "integrity": "sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==",
+      "requires": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.9.1",
+        "intl-messageformat": "^11.1.0"
       }
     },
     "use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lenis": "^1.3.17",
     "lucide-react": "^0.564.0",
     "next": "^16.1.6",
+    "next-intl": "^4.9.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-github-calendar": "^5.0.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import "../styles/global.scss";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { NextIntlClientProvider } from "next-intl";
 import * as gtag from "../lib/gtag";
 import { ThemeProvider } from "../lib/theme-context";
 import Layout from "../components/layout/Layout";
@@ -19,13 +20,15 @@ export default function Portfolio({ Component, pageProps }) {
     };
   }, [router.events]);
 
-  const { siteData, aboutData, ...restPageProps } = pageProps;
+  const { siteData, aboutData, messages, ...restPageProps } = pageProps;
 
   return (
-    <ThemeProvider>
-      <Layout data={siteData} about={aboutData}>
-        <Component {...restPageProps} aboutData={aboutData} />
-      </Layout>
-    </ThemeProvider>
+    <NextIntlClientProvider locale={router.locale} messages={messages}>
+      <ThemeProvider>
+        <Layout data={siteData} about={aboutData}>
+          <Component {...restPageProps} aboutData={aboutData} />
+        </Layout>
+      </ThemeProvider>
+    </NextIntlClientProvider>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import "../styles/global.scss";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { NextIntlClientProvider } from "next-intl";
+import defaultMessages from "../messages/en.json";
 import * as gtag from "../lib/gtag";
 import { ThemeProvider } from "../lib/theme-context";
 import Layout from "../components/layout/Layout";
@@ -23,7 +24,7 @@ export default function Portfolio({ Component, pageProps }) {
   const { siteData, aboutData, messages, ...restPageProps } = pageProps;
 
   return (
-    <NextIntlClientProvider locale={router.locale} messages={messages}>
+    <NextIntlClientProvider locale={router.locale} messages={messages ?? defaultMessages}>
       <ThemeProvider>
         <Layout data={siteData} about={aboutData}>
           <Component {...restPageProps} aboutData={aboutData} />

--- a/pages/blog/[link].tsx
+++ b/pages/blog/[link].tsx
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Profile from "../../components/profile/profile";
 import { useRouter } from "next/router";
+import { useTranslations } from "next-intl";
 
 const MarkdownRenderer = dynamic(() => import("../../components/markdown-renderer/markdown-renderer"), { ssr: true });
 
@@ -75,8 +76,9 @@ interface SingleBlogPageProps {
 
 const SingleBlogPage = ({ blogPost }: SingleBlogPageProps) => {
     const router = useRouter();
+    const t = useTranslations("blog");
     if (!blogPost || Object.keys(blogPost).length === 0) { // Robust check for blogPost
-        return <p>Loading blog post...</p>; 
+        return <p>{t("loading")}</p>;
     }
 
     const { title, banner, profileLink, author, date, content } = blogPost;
@@ -106,7 +108,7 @@ const SingleBlogPage = ({ blogPost }: SingleBlogPageProps) => {
                     </div>
                     <MarkdownRenderer content={content}/>
                     <div className="mt-8">
-                        <span className="text-neutralGray-900 dark:text-white">Share this Post:</span>
+                        <span className="text-neutralGray-900 dark:text-white">{t("sharePost")}</span>
                         <div className="flex justify-flex-start mt-4">
                             {shareArticleList.map((share) => (
                                 <Profile key={share.name} url={share.url} name={share.name} className="w-8 mr-4"/>

--- a/pages/blog/[link].tsx
+++ b/pages/blog/[link].tsx
@@ -43,6 +43,7 @@ export async function getStaticProps(context) {
             aboutData: about,
             // Prop for the SingleBlogPage component
             blogPost: blogPostData,
+            messages: (await import(`../../messages/${context.locale}.json`)).default,
         },
         revalidate: 3600, 
     };

--- a/pages/dev/index.tsx
+++ b/pages/dev/index.tsx
@@ -2,7 +2,7 @@ import { GetStaticProps } from "next";
 import { GitHubCalendar } from "react-github-calendar";
 import Head from "next/head";
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getStaticProps: GetStaticProps = async (context) => {
   const siteDataRes = await fetch(`${process.env.BASE_URL}/site-datas/`);
   const siteDataArray = await siteDataRes.json();
 
@@ -25,6 +25,7 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       siteData: site,
       aboutData: about,
+      messages: (await import(`../../messages/${context.locale}.json`)).default,
     },
     revalidate: 3600,
   };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,7 @@ function toBlogCard(blog: tBlog): BlogCard {
   };
 }
 
-export async function getStaticProps() {
+export async function getStaticProps(context) {
   const [siteDataRes, aboutRes, blogsRes] = await Promise.all([
     fetch(`${process.env.BASE_URL}/site-datas/`),
     fetch(`${process.env.BASE_URL}/abouts/`),
@@ -50,6 +50,7 @@ export async function getStaticProps() {
       aboutData: about,
       bannerData: site.banner,
       blogs: blogsData.map(toBlogCard),
+      messages: (await import(`../messages/${context.locale}.json`)).default,
     },
     revalidate: 3600,
   };

--- a/pages/photo-gallery/index.tsx
+++ b/pages/photo-gallery/index.tsx
@@ -1,7 +1,7 @@
 import Gallery from "../../components/instagram/gallery";
 import Head from "next/head";
 
-export async function getStaticProps() {
+export async function getStaticProps(context) {
   const siteDataRes = await fetch(`${process.env.BASE_URL}/site-datas/`);
   const siteDataArray = await siteDataRes.json();
 
@@ -39,6 +39,7 @@ export async function getStaticProps() {
       siteData: site,
       aboutData: about,
       galleryItems,
+      messages: (await import(`../../messages/${context.locale}.json`)).default,
     },
     revalidate: 3600,
   };

--- a/sections/banner/banner.tsx
+++ b/sections/banner/banner.tsx
@@ -10,6 +10,7 @@ import {
 } from "framer-motion";
 import { ArrowUpRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
 
 interface BannerProps {
   illustration: string;
@@ -25,6 +26,7 @@ const Banner = ({
   ctaUrl,
   downloadable,
 }: BannerProps) => {
+  const t = useTranslations("banner");
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sectionRef = useRef<HTMLElement>(null);
   const prefersReduced = useReducedMotion();
@@ -135,9 +137,9 @@ const Banner = ({
         >
           <h1
             className="text-2xl font-bold leading-tight text-foreground md:text-4xl lg:text-5xl"
-            aria-label={`Hi, I'm ${texts[0]}`}
+            aria-label={`${t("greeting")} ${texts[0]}`}
           >
-            Hi, I&apos;m{" "}
+            {t("greeting")}{" "}
             <span className="relative inline-block" aria-hidden="true">
               <span
                 className="relative z-10 inline-block border-2 border-border bg-main px-2 py-0.5 text-main-foreground shadow-shadow md:px-3 md:py-1"

--- a/sections/blog/blog.tsx
+++ b/sections/blog/blog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import BlogCard from "../../components/blog-card";
 import Section from "../../components/tailwind/section";
@@ -31,6 +32,7 @@ const groupBy = (xs: BlogCardData[], f: (blog: BlogCardData) => string) =>
   );
 
 function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
+  const t = useTranslations("blog");
   const [api, setApi] = useState<CarouselApi>();
   const [current, setCurrent] = useState(0);
   const [count, setCount] = useState(0);
@@ -82,7 +84,7 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
             size="icon"
             onClick={() => api?.scrollPrev()}
             disabled={!canScrollPrev}
-            aria-label="Previous slide"
+            aria-label={t("prevSlide")}
             className="h-9 w-9 shrink-0 rounded-base border-2 border-border disabled:opacity-40"
           >
             <ArrowLeft className="size-4" />
@@ -93,7 +95,7 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
               <button
                 key={i}
                 onClick={() => api?.scrollTo(i)}
-                aria-label={`Go to slide ${i + 1}`}
+                aria-label={t("goToSlide", { number: i + 1 })}
                 className={cn(
                   "h-2.5 rounded-full border-2 border-border shadow-[1px_1px_0px_0px_#000000] transition-all duration-200",
                   i === current ? "w-6 bg-main" : "w-2.5 bg-secondary-background",
@@ -107,7 +109,7 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
             size="icon"
             onClick={() => api?.scrollNext()}
             disabled={!canScrollNext}
-            aria-label="Next slide"
+            aria-label={t("nextSlide")}
             className="h-9 w-9 shrink-0 rounded-base border-2 border-border disabled:opacity-40"
           >
             <ArrowRight className="size-4" />

--- a/sections/experience/experience.tsx
+++ b/sections/experience/experience.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import Section from "../../components/tailwind/section";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -26,8 +27,9 @@ interface ExperienceProps {
 }
 
 const Experience = ({ experience }: ExperienceProps) => {
+  const t = useTranslations("experience");
   return (
-    <Section container id="experience" heading="Experience">
+    <Section container id="experience" heading={t("title")}>
       <Accordion type="single" collapsible className="w-full space-y-3">
         {experience.map((entry, index) => (
           <motion.div

--- a/sections/footer/footer.test.tsx
+++ b/sections/footer/footer.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import Footer from "./footer";
 
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    locales: ["en"],
+    locale: "en",
+    asPath: "/",
+  }),
+}));
+
 jest.mock("../../components/profile/profile", () => ({
   __esModule: true,
   default: ({ name, url }: { name: string; url: string }) => (

--- a/sections/footer/footer.tsx
+++ b/sections/footer/footer.tsx
@@ -8,6 +8,7 @@ import {
   useReducedMotion,
 } from "framer-motion";
 import Profile from "../../components/profile/profile";
+import { useTranslations } from "next-intl";
 
 const Footer = ({
   profiles,
@@ -16,6 +17,7 @@ const Footer = ({
 }) => {
   const footerRef = useRef<HTMLElement>(null);
   const prefersReduced = useReducedMotion();
+  const t = useTranslations("footer");
 
   const { scrollYProgress } = useScroll({
     target: footerRef,
@@ -34,10 +36,10 @@ const Footer = ({
       <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
         <div className="flex flex-col">
           <h3 className="mb-2 text-2xl font-bold text-foreground">
-            Thank you for stopping by!
+            {t("thanks")}
           </h3>
           <p className="mb-4 text-foreground md:mb-0">
-            Let&apos;s get in touch on any of these platforms.
+            {t("getInTouch")}
           </p>
         </div>
         <div className="flex gap-4">
@@ -71,7 +73,7 @@ const Footer = ({
           rel="noreferrer"
           className="underline hover:no-underline"
         >
-          License
+          {t("license")}
         </a>
       </div>
     </motion.footer>

--- a/sections/footer/footer.tsx
+++ b/sections/footer/footer.tsx
@@ -9,6 +9,7 @@ import {
 } from "framer-motion";
 import Profile from "../../components/profile/profile";
 import { useTranslations } from "next-intl";
+import { LanguageSwitcher } from "../../components/language-switcher/language-switcher";
 
 const Footer = ({
   profiles,
@@ -55,7 +56,7 @@ const Footer = ({
         </div>
       </div>
       <hr className="my-6 border-border" />
-      <div className="flex flex-col gap-2 text-sm text-foreground sm:flex-row sm:justify-between">
+      <div className="flex flex-col gap-2 text-sm text-foreground sm:flex-row sm:justify-between sm:items-center">
         <span>
           &copy; {new Date().getFullYear()}{" "}
           <a
@@ -67,14 +68,17 @@ const Footer = ({
             Prasheel
           </a>
         </span>
-        <a
-          href="https://github.com/ps011/ps11/LICENSE.md"
-          target="_blank"
-          rel="noreferrer"
-          className="underline hover:no-underline"
-        >
-          {t("license")}
-        </a>
+        <div className="flex items-center gap-4">
+          <LanguageSwitcher />
+          <a
+            href="https://github.com/ps011/ps11/LICENSE.md"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:no-underline"
+          >
+            {t("license")}
+          </a>
+        </div>
       </div>
     </motion.footer>
   );

--- a/sections/interests/interests.tsx
+++ b/sections/interests/interests.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import Section from "../../components/tailwind/section";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,8 @@ const item = {
 };
 
 const Interests = ({ illustration, interests }: InterestsProps) => {
+  const t = useTranslations("interests");
+  const tc = useTranslations("common");
   const getInterestType = (
     title: string,
   ): "blogging" | "photography" | "coding" | "other" => {
@@ -57,7 +60,7 @@ const Interests = ({ illustration, interests }: InterestsProps) => {
         return (
           <Button variant="default" size="default" asChild>
             <Link href="/blog" className="no-underline">
-              View My Blog Posts
+              {t("viewBlog")}
             </Link>
           </Button>
         );
@@ -65,7 +68,7 @@ const Interests = ({ illustration, interests }: InterestsProps) => {
         return (
           <Button variant="default" size="default" asChild>
             <Link href="/photo-gallery" className="no-underline">
-              Explore Photo Gallery
+              {t("viewGallery")}
             </Link>
           </Button>
         );
@@ -78,14 +81,14 @@ const Interests = ({ illustration, interests }: InterestsProps) => {
               rel="noopener noreferrer"
               className="no-underline"
             >
-              View My GitHub
+              {t("viewGithub")}
             </Link>
           </Button>
         );
       default:
         return (
           <Button variant="neutral" size="default" disabled>
-            Coming Soon
+            {tc("comingSoon")}
           </Button>
         );
     }


### PR DESCRIPTION
## Summary

- Add `next-intl` with Next.js subpath routing for i18n support
- Extract all hardcoded UI strings into `messages/en.json` (6 namespaces: common, banner, experience, interests, blog, footer)
- Wire up `NextIntlClientProvider` in `_app.tsx` with fallback messages for pages without `getStaticProps`
- Replace hardcoded strings in 9 components with `useTranslations` hook
- Add `LanguageSwitcher` component in footer (auto-hidden when single locale)
- Add Jest mock for next-intl (ESM-only) so all existing tests continue to pass

**To add a new language later:** add locale to `next.config.js`, create `messages/es.json`, switcher appears automatically.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 71/71 tests pass (11 suites)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run build` — 17/17 pages generated with `/en/` prefix
- [x] No hardcoded UI strings remain in updated components
- [ ] Visual verification on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)