### PR TITLE
feat(analytics): add GA4 event tracking

### DIFF
--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@prasheel/ui";
+import { trackSelectContent } from "@/lib/gtag";
 
 interface BlogCardProps {
   thumbnail: string;
@@ -38,6 +39,8 @@ const BlogCard = ({
 
   const getLink = (href: string) =>
     href.startsWith("http") ? href : `/blog/${href}`;
+
+  const href = getLink(link);
 
   return (
     <motion.div
@@ -81,7 +84,22 @@ const BlogCard = ({
         </CardContent>
         <CardFooter className="pt-0">
           <Button variant="default" size="default" className="w-full" asChild>
-            <Link href={getLink(link)} target="_blank" rel="noopener noreferrer" className="no-underline">
+            <Link
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline"
+              onClick={() =>
+                trackSelectContent({
+                  section: "blog_card",
+                  content_type: "blog",
+                  item_id: link,
+                  item_name: title,
+                  link_url: href,
+                  link_text: t("readMore"),
+                })
+              }
+            >
               {t("readMore")}
             </Link>
           </Button>

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Menu } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { trackClick } from "@/lib/gtag";
 import {
   Button,
   Sheet,
@@ -36,13 +37,32 @@ export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
     return `/${href}`;
   };
 
+  const getLabel = (href: string) =>
+    navKeyMap[href] ? tNav(navKeyMap[href]) : href;
+
+  const trackNavClick = (href: string) => {
+    const label = getLabel(href);
+    trackClick({
+      section: "header",
+      content_type: "nav",
+      item_id: href,
+      item_name: label,
+      link_url: getHref(href),
+      link_text: label,
+    });
+  };
+
   const navLinks = (
     <>
       {navMap.length > 0 &&
         navMap.map((item) => (
           <Button key={item.href} variant="neutral" size="default" asChild>
-            <Link href={getHref(item.href)} className="no-underline">
-              {navKeyMap[item.href] ? tNav(navKeyMap[item.href]) : item.href}
+            <Link
+              href={getHref(item.href)}
+              className="no-underline"
+              onClick={() => trackNavClick(item.href)}
+            >
+              {getLabel(item.href)}
             </Link>
           </Button>
         ))}
@@ -52,7 +72,20 @@ export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
   return (
     <header className="sticky top-0 z-40 w-full border-b-2 border-border bg-main py-4 shadow-shadow md:py-6">
       <div className="container flex justify-between items-center">
-        <Link href="/" className="flex-shrink-0">
+        <Link
+          href="/"
+          className="flex-shrink-0"
+          onClick={() =>
+            trackClick({
+              section: "header",
+              content_type: "nav",
+              item_id: "logo",
+              item_name: "Logo",
+              link_url: "/",
+              link_text: "Logo",
+            })
+          }
+        >
           <Image
             height={56}
             width={250}
@@ -95,7 +128,12 @@ export const Header: React.FC<HeaderProps> = ({ logoUrl, navMap = [] }) => {
                         className="w-full justify-start text-left"
                         asChild
                       >
-                        <Link href={getHref(item.href)}>{navKeyMap[item.href] ? tNav(navKeyMap[item.href]) : item.href}</Link>
+                        <Link
+                          href={getHref(item.href)}
+                          onClick={() => trackNavClick(item.href)}
+                        >
+                          {getLabel(item.href)}
+                        </Link>
                       </Button>
                     </li>
                   ))}

--- a/components/instagram/gallery.tsx
+++ b/components/instagram/gallery.tsx
@@ -4,6 +4,7 @@ import exifr from "exifr";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import type { GalleryImage } from "../../interfaces/photo-gallery";
 import { Button } from "@prasheel/ui";
+import { trackSelectContent, trackSelectItem } from "@/lib/gtag";
 
 interface ExifData {
     camera?: string;
@@ -55,16 +56,57 @@ export default function PhotoGallery({ galleryItems }: PhotoGalleryProps) {
         [galleryItems],
     );
 
-    const openLightbox = useCallback((index: number) => setLightboxIndex(index), []);
-    const closeLightbox = useCallback(() => setLightboxIndex(null), []);
+    const trackPhotoAction = useCallback((action: string, image?: GalleryImage) => {
+        trackSelectItem({
+            section: "photo_gallery",
+            content_type: "photo",
+            item_id: image?.id || action,
+            item_name: image?.caption || image?.location || image?.category || action,
+            action,
+        });
+    }, []);
+
+    const handleFilterChange = useCallback((category: string) => {
+        setActiveFilter(category);
+        trackSelectItem({
+            section: "photo_gallery",
+            content_type: "category",
+            item_id: category,
+            item_name: category === "all" ? "All" : category,
+        });
+    }, []);
+
+    const openLightbox = useCallback((index: number) => {
+        const image = filteredImages[index];
+        trackSelectContent({
+            section: "photo_gallery",
+            content_type: "photo",
+            item_id: image?.id || `photo_${index + 1}`,
+            item_name: image?.caption || image?.location || image?.category || `Photo ${index + 1}`,
+        });
+        setLightboxIndex(index);
+    }, [filteredImages]);
+
+    const closeLightbox = useCallback(() => {
+        if (lightboxIndex !== null) {
+            trackPhotoAction("close_lightbox", filteredImages[lightboxIndex]);
+        }
+        setLightboxIndex(null);
+    }, [filteredImages, lightboxIndex, trackPhotoAction]);
 
     const showPrev = useCallback(() => {
-        setLightboxIndex((i) => (i === null ? null : (i - 1 + filteredImages.length) % filteredImages.length));
-    }, [filteredImages.length]);
+        if (lightboxIndex === null || filteredImages.length === 0) return;
+        const nextIndex = (lightboxIndex - 1 + filteredImages.length) % filteredImages.length;
+        trackPhotoAction("previous_lightbox_photo", filteredImages[nextIndex]);
+        setLightboxIndex(nextIndex);
+    }, [filteredImages, lightboxIndex, trackPhotoAction]);
 
     const showNext = useCallback(() => {
-        setLightboxIndex((i) => (i === null ? null : (i + 1) % filteredImages.length));
-    }, [filteredImages.length]);
+        if (lightboxIndex === null || filteredImages.length === 0) return;
+        const nextIndex = (lightboxIndex + 1) % filteredImages.length;
+        trackPhotoAction("next_lightbox_photo", filteredImages[nextIndex]);
+        setLightboxIndex(nextIndex);
+    }, [filteredImages, lightboxIndex, trackPhotoAction]);
 
     useEffect(() => {
         setLightboxIndex(null);
@@ -210,7 +252,7 @@ export default function PhotoGallery({ galleryItems }: PhotoGalleryProps) {
                             key={cat}
                             variant={activeFilter === cat ? "default" : "neutral"}
                             size="sm"
-                            onClick={() => setActiveFilter(cat)}
+                            onClick={() => handleFilterChange(cat)}
                         >
                             {cat === "all" ? "All" : cat}
                         </Button>
@@ -344,7 +386,11 @@ export default function PhotoGallery({ galleryItems }: PhotoGalleryProps) {
                                             key={img.id}
                                             ref={isActive ? activeThumbRef : undefined}
                                             type="button"
-                                            onClick={(e) => { e.stopPropagation(); setLightboxIndex(i); }}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                trackPhotoAction("thumbnail_select", img);
+                                                setLightboxIndex(i);
+                                            }}
                                             className={`relative h-14 w-20 shrink-0 overflow-hidden rounded transition-all duration-200 ${isActive ? "ring-2 ring-white opacity-100 scale-105" : "opacity-50 hover:opacity-90"}`}
                                             aria-label={`View image ${i + 1}`}
                                             aria-current={isActive}

--- a/components/language-switcher/language-switcher.tsx
+++ b/components/language-switcher/language-switcher.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Button } from "@prasheel/ui";
+import { trackClick } from "@/lib/gtag";
 
 export const LanguageSwitcher = () => {
   const { locales, locale: currentLocale, asPath } = useRouter();
@@ -21,6 +22,16 @@ export const LanguageSwitcher = () => {
             locale={locale}
             aria-current={locale === currentLocale ? "true" : undefined}
             className="no-underline"
+            onClick={() =>
+              trackClick({
+                section: "footer",
+                content_type: "language",
+                item_id: locale,
+                item_name: locale.toUpperCase(),
+                link_url: asPath,
+                link_text: locale.toUpperCase(),
+              })
+            }
           >
             {locale.toUpperCase()}
           </Link>

--- a/components/profile/profile.tsx
+++ b/components/profile/profile.tsx
@@ -7,14 +7,33 @@ import Instagram from "../icons/instagram";
 import Stackoverflow from "../icons/stackoverflow";
 import { Button } from "@prasheel/ui";
 import { cn } from "@/lib/utils";
+import { trackClick } from "@/lib/gtag";
+
+type ProfileAnalytics =
+  | false
+  | {
+      section?: string;
+      contentType?: string;
+      itemId?: string;
+      itemName?: string;
+      linkText?: string;
+    };
 
 interface ProfileProps {
   url: string;
   name: string;
   className?: string;
+  analytics?: ProfileAnalytics;
+  onClick?: () => void;
 }
 
-const Profile = ({ url, name, className }: ProfileProps) => {
+const Profile = ({
+  url,
+  name,
+  className,
+  analytics,
+  onClick,
+}: ProfileProps) => {
 
   const getProfileIcon = (name: string) => {
     switch (name) {
@@ -36,6 +55,20 @@ const Profile = ({ url, name, className }: ProfileProps) => {
     }
   };
 
+  const handleClick = () => {
+    if (analytics !== false) {
+      trackClick({
+        section: analytics?.section || "profile",
+        content_type: analytics?.contentType || "profile",
+        item_id: analytics?.itemId || name,
+        item_name: analytics?.itemName || name,
+        link_url: url,
+        link_text: analytics?.linkText || `${name} profile`,
+      });
+    }
+    onClick?.();
+  };
+
   return (
     <Button variant="default" size="icon" className="[&_svg]:size-6" asChild>
       <Link
@@ -44,6 +77,7 @@ const Profile = ({ url, name, className }: ProfileProps) => {
         rel="noopener noreferrer"
         aria-label={`${name} profile`}
         className="no-underline"
+        onClick={handleClick}
       >
         <span className={cn("block size-6 text-main-foreground", className)} aria-hidden="true">
           {getProfileIcon(name)}

--- a/docs/superpowers/plans/2026-05-22-ga4-analytics.md
+++ b/docs/superpowers/plans/2026-05-22-ga4-analytics.md
@@ -1,0 +1,248 @@
+# GA4 Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the portfolio from legacy Universal Analytics page views to GA4 page views plus focused interaction events.
+
+**Architecture:** Keep analytics centralized in `lib/gtag.js` with safe no-op behavior outside production or before `window.gtag` loads. Render GA scripts from `_app.tsx` through `next/script`, remove custom document GA injection, and have components call semantic helper functions for trackable interactions.
+
+**Tech Stack:** Next.js Pages Router, React, TypeScript/JavaScript, Jest, React Testing Library, Google tag (`gtag.js`).
+
+---
+
+## File Structure
+
+- Modify `lib/gtag.js`: convert the existing page-view wrapper into a GA4 helper module with production gating and semantic event helpers.
+- Create `lib/gtag.test.ts`: unit tests for page views, events, no-op guards, and helper payloads.
+- Modify `pages/_app.tsx`: render `next/script` GA setup and keep route-change page views.
+- Modify `pages/_document.tsx`: remove GA script injection and leave theme/font document behavior intact.
+- Modify `components/header/header.tsx`: track logo and nav clicks.
+- Modify `components/profile/profile.tsx`: track outbound profile/social clicks.
+- Modify `components/language-switcher/language-switcher.tsx`: track locale selection.
+- Modify `components/blog-card.tsx`: track blog read clicks.
+- Modify `sections/banner/banner.tsx`: track banner CTA clicks.
+- Modify `sections/blog-index/blog-index.tsx`: track search and tag filters.
+- Modify `sections/blog/blog.tsx`: track carousel controls.
+- Modify `pages/blog/[link].tsx`: track author and share clicks.
+- Modify `components/instagram/gallery.tsx`: track gallery filters and lightbox actions.
+
+## Task 1: Analytics Helper Tests
+
+**Files:**
+- Create: `lib/gtag.test.ts`
+- Modify: `lib/gtag.js`
+
+- [ ] **Step 1: Write failing tests for the GA wrapper**
+
+Create `lib/gtag.test.ts` with tests equivalent to:
+
+```ts
+const originalNodeEnv = process.env.NODE_ENV;
+
+const loadGtag = () => {
+  jest.resetModules();
+  return require("./gtag");
+};
+
+describe("gtag analytics helpers", () => {
+  beforeEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: "production",
+      configurable: true,
+    });
+    (window as any).gtag = jest.fn();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: originalNodeEnv,
+      configurable: true,
+    });
+    delete (window as any).gtag;
+  });
+
+  it("uses the GA4 measurement ID", () => {
+    const { GA_MEASUREMENT_ID } = loadGtag();
+    expect(GA_MEASUREMENT_ID).toBe("G-57NC87VXFC");
+  });
+
+  it("tracks page views in production", () => {
+    const { pageview, GA_MEASUREMENT_ID } = loadGtag();
+    pageview("/blog");
+    expect(window.gtag).toHaveBeenCalledWith("config", GA_MEASUREMENT_ID, {
+      page_path: "/blog",
+    });
+  });
+
+  it("tracks events in production", () => {
+    const { event } = loadGtag();
+    event("click", { section: "banner", link_text: "Resume" });
+    expect(window.gtag).toHaveBeenCalledWith("event", "click", {
+      section: "banner",
+      link_text: "Resume",
+    });
+  });
+
+  it("does not throw when gtag is unavailable", () => {
+    delete (window as any).gtag;
+    const { event, pageview } = loadGtag();
+    expect(() => pageview("/")).not.toThrow();
+    expect(() => event("click", { section: "header" })).not.toThrow();
+  });
+
+  it("no-ops outside production", () => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: "development",
+      configurable: true,
+    });
+    const { pageview } = loadGtag();
+    pageview("/");
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run: `npm test -- lib/gtag.test.ts`
+
+Expected: FAIL because `GA_MEASUREMENT_ID` and `event` are not implemented.
+
+## Task 2: GA4 Runtime Wiring
+
+**Files:**
+- Modify: `lib/gtag.js`
+- Modify: `pages/_app.tsx`
+- Modify: `pages/_document.tsx`
+- Test: `lib/gtag.test.ts`
+
+- [ ] **Step 1: Implement the helper module**
+
+Update `lib/gtag.js` to expose:
+
+```js
+export const GA_MEASUREMENT_ID =
+  process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || "G-57NC87VXFC";
+
+export const isProduction = process.env.NODE_ENV === "production";
+
+const canTrack = () =>
+  isProduction &&
+  Boolean(GA_MEASUREMENT_ID) &&
+  typeof window !== "undefined" &&
+  typeof window.gtag === "function";
+
+export const pageview = (url) => {
+  if (!canTrack()) return;
+  window.gtag("config", GA_MEASUREMENT_ID, {
+    page_path: url,
+  });
+};
+
+export const event = (name, params = {}) => {
+  if (!canTrack()) return;
+  window.gtag("event", name, params);
+};
+```
+
+- [ ] **Step 2: Render GA scripts in `_app.tsx`**
+
+Use `next/script`, render scripts only in production with a configured measurement ID, and keep route-change page views. The scripts should load `https://www.googletagmanager.com/gtag/js?id=${gtag.GA_MEASUREMENT_ID}` and initialize `window.dataLayer`, `gtag("js", new Date())`, and `gtag("config", measurementId, { page_path: window.location.pathname })`.
+
+- [ ] **Step 3: Remove GA scripts from `_document.tsx`**
+
+Delete the `GA_TRACKING_ID` import, `isProduction` constant, and GA script block. Keep theme preset script, font links, body, `Main`, and `NextScript` unchanged.
+
+- [ ] **Step 4: Run the focused helper test**
+
+Run: `npm test -- lib/gtag.test.ts`
+
+Expected: PASS.
+
+## Task 3: Interaction Event Instrumentation
+
+**Files:**
+- Modify: `lib/gtag.js`
+- Modify: `components/header/header.tsx`
+- Modify: `components/profile/profile.tsx`
+- Modify: `components/language-switcher/language-switcher.tsx`
+- Modify: `components/blog-card.tsx`
+- Modify: `sections/banner/banner.tsx`
+- Modify: `sections/blog-index/blog-index.tsx`
+- Modify: `sections/blog/blog.tsx`
+- Modify: `pages/blog/[link].tsx`
+- Modify: `components/instagram/gallery.tsx`
+
+- [ ] **Step 1: Add semantic helper functions**
+
+Add helpers to `lib/gtag.js` that wrap `event`, including:
+
+```js
+export const trackClick = (params) => event("click", params);
+export const trackSelectContent = (params) => event("select_content", params);
+export const trackSelectItem = (params) => event("select_item", params);
+export const trackSearch = (params) => event("search", params);
+export const trackShare = (params) => event("share", params);
+```
+
+- [ ] **Step 2: Track CTA, nav, profile, and language clicks**
+
+Add `onClick` handlers that call the relevant helper with stable parameters:
+
+```ts
+gtag.trackClick({
+  section: "banner",
+  content_type: "cta",
+  link_url: ctaUrl,
+  link_text: translatedCtaLabel,
+});
+```
+
+Use analogous payloads for header nav/logo, profile links, and language links.
+
+- [ ] **Step 3: Track blog interactions**
+
+Add helper calls for blog reads, search input changes, tag filters, carousel controls, author profile clicks, and share links. Use `content_type: "blog"` for reads and shares, `section: "blog_index"` for search/filter events, and include `item_id` or `item_name` where available.
+
+- [ ] **Step 4: Track gallery interactions**
+
+Add helper calls for category filters, lightbox open/close, previous/next, and thumbnail selection. Include `content_type: "photo"`, `section: "photo_gallery"`, and `item_id`/`item_name` from the selected image.
+
+- [ ] **Step 5: Run impacted tests**
+
+Run:
+
+```bash
+npm test -- lib/gtag.test.ts components/header sections/blog sections/blog-index __tests__/components/language-switcher.test.tsx
+```
+
+Expected: PASS.
+
+## Task 4: Final Verification
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run lint**
+
+Run: `npm run lint`
+
+Expected: PASS with no lint errors.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run production build**
+
+Run: `npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 4: Review git diff**
+
+Run: `git diff --stat && git diff -- lib/gtag.js pages/_app.tsx pages/_document.tsx`
+
+Expected: Diff is limited to analytics helper, GA runtime wiring, event instrumentation, tests, and docs.

--- a/docs/superpowers/specs/2026-05-22-ga4-analytics-design.md
+++ b/docs/superpowers/specs/2026-05-22-ga4-analytics-design.md
@@ -1,0 +1,88 @@
+# GA4 Analytics Design
+
+## Context
+
+The app currently loads Google Analytics in production through `pages/_document.tsx` and sends client-side route-change page views from `pages/_app.tsx`. The configured ID is the legacy Universal Analytics ID `UA-151206536-1`, which should be replaced with the GA4 Measurement ID `G-57NC87VXFC`.
+
+The current implementation only captures page views. The goal is to keep GA integration simple while adding useful event coverage for portfolio behavior.
+
+## Goals
+
+- Use GA4 through the provided Measurement ID.
+- Keep analytics disabled outside production.
+- Preserve page-view tracking for initial loads and client-side route changes.
+- Add structured events for high-intent interactions.
+- Keep event helpers centralized so component code does not call `window.gtag` directly.
+
+## Non-Goals
+
+- No Google Tag Manager migration.
+- No server-side Measurement Protocol.
+- No cookie consent UI.
+- No scroll-depth, read-depth, or timing events in this iteration.
+
+## Architecture
+
+Analytics remains a lightweight client-side integration:
+
+- `lib/gtag` owns the Measurement ID, GA readiness checks, page-view tracking, and event helper functions.
+- `_document` no longer injects GA script tags. GA scripts should load through Next's runtime script mechanism so they are not embedded in the custom document lifecycle.
+- `_app` renders the GA script component, sends route-change page views, and keeps production gating centralized.
+- Components import semantic helper functions from `lib/gtag` instead of building GA payloads inline.
+
+The Measurement ID should come from `NEXT_PUBLIC_GA_MEASUREMENT_ID`, with `G-57NC87VXFC` as the current fallback so production works even before hosting env vars are updated.
+
+## Event Contract
+
+Use GA4-style event names with lower-case snake case:
+
+- `select_content` for opening or reading site content.
+- `search` for blog search.
+- `share` for blog share actions.
+- `select_item` for category, tag, carousel, and gallery selections.
+- `click` for outbound links, nav links, and CTAs.
+
+Shared parameters:
+
+- `section`: UI area, such as `header`, `banner`, `footer`, `blog_index`, or `photo_gallery`.
+- `link_url`: destination URL when applicable.
+- `link_text`: visible label or stable action name.
+- `content_type`: type such as `blog`, `profile`, `photo`, `nav`, `cta`, or `language`.
+- `item_id`: stable identifier for blog links, photo IDs, tags, categories, or locale codes.
+- `item_name`: human-readable title, label, category, or provider name.
+
+Initial event coverage:
+
+- Banner CTA/resume clicks.
+- Profile/social outbound clicks.
+- Header navigation and logo clicks.
+- Language switches.
+- Blog card read clicks.
+- Blog search query changes.
+- Blog tag filters.
+- Blog share clicks.
+- Blog carousel previous, next, and dot selection.
+- Gallery category filters.
+- Gallery lightbox open, close, previous, next, and thumbnail selection.
+
+## Error Handling
+
+Analytics helpers must safely no-op when:
+
+- `NODE_ENV` is not `production`.
+- `window` is unavailable.
+- `window.gtag` has not loaded.
+- The Measurement ID is missing.
+
+This prevents tests, server rendering, and development browsing from throwing or sending accidental data.
+
+## Testing
+
+Add focused tests for `lib/gtag`:
+
+- Page views call `gtag("config", measurementId, ...)` in production.
+- Events call `gtag("event", eventName, params)` in production.
+- Missing `window.gtag` does not throw.
+- Non-production environments no-op.
+
+Existing component tests should continue to pass. Run the full Jest suite after implementation.

--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,8 +1,34 @@
-export const GA_TRACKING_ID = "UA-151206536-1";
+export const GA_MEASUREMENT_ID =
+  process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || "G-57NC87VXFC";
+
+export const isProduction = process.env.NODE_ENV === "production";
+
+const canTrack = () =>
+  isProduction &&
+  Boolean(GA_MEASUREMENT_ID) &&
+  typeof window !== "undefined" &&
+  typeof window.gtag === "function";
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url) => {
-  window.gtag("config", GA_TRACKING_ID, {
+  if (!canTrack()) return;
+  window.gtag("config", GA_MEASUREMENT_ID, {
     page_path: url,
   });
 };
+
+export const event = (name, params = {}) => {
+  if (!canTrack()) return;
+  window.gtag("event", name, params);
+};
+
+export const trackClick = (params) => event("click", params);
+
+export const trackSelectContent = (params) =>
+  event("select_content", params);
+
+export const trackSelectItem = (params) => event("select_item", params);
+
+export const trackSearch = (params) => event("search", params);
+
+export const trackShare = (params) => event("share", params);

--- a/lib/gtag.test.ts
+++ b/lib/gtag.test.ts
@@ -1,0 +1,136 @@
+type GtagWindow = Window & {
+  gtag?: jest.Mock;
+};
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+const setNodeEnv = (value: string) => {
+  Object.defineProperty(process.env, "NODE_ENV", {
+    value,
+    configurable: true,
+  });
+};
+
+const restoreMeasurementId = () => {
+  if (originalMeasurementId === undefined) {
+    delete process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+    return;
+  }
+  process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = originalMeasurementId;
+};
+
+const loadGtag = () => {
+  jest.resetModules();
+  return require("./gtag");
+};
+
+describe("gtag analytics helpers", () => {
+  beforeEach(() => {
+    setNodeEnv("production");
+    delete process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+    (window as GtagWindow).gtag = jest.fn();
+  });
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+    restoreMeasurementId();
+    delete (window as GtagWindow).gtag;
+  });
+
+  it("uses the GA4 measurement ID fallback", () => {
+    const { GA_MEASUREMENT_ID } = loadGtag();
+
+    expect(GA_MEASUREMENT_ID).toBe("G-57NC87VXFC");
+  });
+
+  it("prefers the configured public measurement ID", () => {
+    process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = "G-TEST12345";
+
+    const { GA_MEASUREMENT_ID } = loadGtag();
+
+    expect(GA_MEASUREMENT_ID).toBe("G-TEST12345");
+  });
+
+  it("tracks page views in production", () => {
+    const { pageview, GA_MEASUREMENT_ID } = loadGtag();
+
+    pageview("/blog");
+
+    expect((window as GtagWindow).gtag).toHaveBeenCalledWith(
+      "config",
+      GA_MEASUREMENT_ID,
+      { page_path: "/blog" },
+    );
+  });
+
+  it("tracks events in production", () => {
+    const { event } = loadGtag();
+
+    event("click", { section: "banner", link_text: "Resume" });
+
+    expect((window as GtagWindow).gtag).toHaveBeenCalledWith("event", "click", {
+      section: "banner",
+      link_text: "Resume",
+    });
+  });
+
+  it("does not throw when gtag is unavailable", () => {
+    delete (window as GtagWindow).gtag;
+    const { event, pageview } = loadGtag();
+
+    expect(() => pageview("/")).not.toThrow();
+    expect(() => event("click", { section: "header" })).not.toThrow();
+  });
+
+  it("no-ops outside production", () => {
+    setNodeEnv("development");
+    const { pageview } = loadGtag();
+
+    pageview("/");
+
+    expect((window as GtagWindow).gtag).not.toHaveBeenCalled();
+  });
+
+  it("provides semantic event helpers", () => {
+    const { trackClick, trackSelectContent, trackSelectItem, trackSearch, trackShare } =
+      loadGtag();
+
+    trackClick({ section: "header" });
+    trackSelectContent({ content_type: "blog", item_id: "post" });
+    trackSelectItem({ content_type: "photo", item_id: "photo-1" });
+    trackSearch({ search_term: "analytics" });
+    trackShare({ method: "linkedin", content_type: "blog" });
+
+    expect((window as GtagWindow).gtag).toHaveBeenNthCalledWith(
+      1,
+      "event",
+      "click",
+      { section: "header" },
+    );
+    expect((window as GtagWindow).gtag).toHaveBeenNthCalledWith(
+      2,
+      "event",
+      "select_content",
+      { content_type: "blog", item_id: "post" },
+    );
+    expect((window as GtagWindow).gtag).toHaveBeenNthCalledWith(
+      3,
+      "event",
+      "select_item",
+      { content_type: "photo", item_id: "photo-1" },
+    );
+    expect((window as GtagWindow).gtag).toHaveBeenNthCalledWith(
+      4,
+      "event",
+      "search",
+      { search_term: "analytics" },
+    );
+    expect((window as GtagWindow).gtag).toHaveBeenNthCalledWith(
+      5,
+      "event",
+      "share",
+      { method: "linkedin", content_type: "blog" },
+    );
+  });
+});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import "../styles/global.scss";
 import "@prasheel/ui/styles.css";
 import { useRouter } from "next/router";
+import Script from "next/script";
 import { useEffect } from "react";
 import { NextIntlClientProvider } from "next-intl";
 import defaultMessages from "../messages/en.json";
@@ -8,7 +9,6 @@ import * as gtag from "../lib/gtag";
 import { ThemeProvider } from "@prasheel/ui";
 import Layout from "../components/layout/Layout";
 
-const isProduction = process.env.NODE_ENV === "production";
 const themeStorageKeys = {
   themeId: "portfolio-theme",
   darkMode: "portfolio-dark-mode",
@@ -16,9 +16,11 @@ const themeStorageKeys = {
 
 export default function Portfolio({ Component, pageProps }) {
   const router = useRouter();
+  const isAnalyticsEnabled = gtag.isProduction && Boolean(gtag.GA_MEASUREMENT_ID);
+
   useEffect(() => {
     const handleRouteChange = (url) => {
-      if (isProduction) gtag.pageview(url);
+      gtag.pageview(url);
     };
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => {
@@ -29,16 +31,37 @@ export default function Portfolio({ Component, pageProps }) {
   const { siteData, aboutData, messages, ...restPageProps } = pageProps;
 
   return (
-    <NextIntlClientProvider locale={router.locale} messages={messages ?? defaultMessages}>
-      <ThemeProvider
-        defaultThemeId="blue"
-        defaultDarkMode={false}
-        storageKeys={themeStorageKeys}
-      >
-        <Layout data={siteData} about={aboutData}>
-          <Component {...restPageProps} aboutData={aboutData} />
-        </Layout>
-      </ThemeProvider>
-    </NextIntlClientProvider>
+    <>
+      {isAnalyticsEnabled && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_MEASUREMENT_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script id="google-analytics" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){window.dataLayer.push(arguments);}
+              window.gtag = window.gtag || gtag;
+              gtag('js', new Date());
+              gtag('config', '${gtag.GA_MEASUREMENT_ID}', {
+                page_path: window.location.pathname + window.location.search,
+              });
+            `}
+          </Script>
+        </>
+      )}
+      <NextIntlClientProvider locale={router.locale} messages={messages ?? defaultMessages}>
+        <ThemeProvider
+          defaultThemeId="blue"
+          defaultDarkMode={false}
+          storageKeys={themeStorageKeys}
+        >
+          <Layout data={siteData} about={aboutData}>
+            <Component {...restPageProps} aboutData={aboutData} />
+          </Layout>
+        </ThemeProvider>
+      </NextIntlClientProvider>
+    </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,11 +1,7 @@
 import { Html, Head, Main, NextScript } from "next/document";
 import { themePresets } from "@prasheel/ui";
 
-import { GA_TRACKING_ID } from "../lib/gtag";
-
 const themePresetsJson = JSON.stringify(themePresets);
-
-const isProduction = process.env.NODE_ENV === "production";
 
 export default function Document() {
   return (
@@ -30,28 +26,6 @@ export default function Document() {
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" />
           <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet" />
-        {/* enable analytics script only for production */}
-        {isProduction && (
-            <>
-                <script
-                    async
-                    src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
-                />
-                <script
-                     
-                    dangerouslySetInnerHTML={{
-                        __html: `
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${GA_TRACKING_ID}', {
-            page_path: window.location.pathname,
-          });
-        `,
-                    }}
-                />
-            </>
-        )}
       </Head>
         <body className="bg-background text-foreground antialiased overflow-x-hidden">
         <Main/>

--- a/pages/blog/[link].tsx
+++ b/pages/blog/[link].tsx
@@ -7,6 +7,7 @@ import BlogHero from "../../components/blog-hero/blog-hero";
 import { useRouter } from "next/router";
 import { useTranslations } from "next-intl";
 import { Button, Card, CardContent } from "@prasheel/ui";
+import { trackClick, trackShare } from "@/lib/gtag";
 import { getSiteData, getAboutData, getBlogs, getBlogByLink } from "../../lib/data";
 
 const MarkdownRenderer = dynamic(() => import("../../components/markdown-renderer/markdown-renderer"), { ssr: true });
@@ -136,6 +137,16 @@ const SingleBlogPage = ({ blogPost }: SingleBlogPageProps) => {
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="text-sm font-semibold text-foreground underline decoration-2 underline-offset-2 hover:opacity-70"
+                                    onClick={() =>
+                                        trackClick({
+                                            section: "blog_detail",
+                                            content_type: "profile",
+                                            item_id: author,
+                                            item_name: author,
+                                            link_url: profileLink,
+                                            link_text: author,
+                                        })
+                                    }
                                 >
                                     {author}
                                 </a>
@@ -165,6 +176,17 @@ const SingleBlogPage = ({ blogPost }: SingleBlogPageProps) => {
                                             url={share.url}
                                             name={share.name}
                                             className="w-8"
+                                            analytics={false}
+                                            onClick={() =>
+                                                trackShare({
+                                                    section: "blog_detail",
+                                                    content_type: "blog",
+                                                    item_id: router.query.link || title,
+                                                    item_name: title,
+                                                    method: share.name,
+                                                    link_url: share.url,
+                                                })
+                                            }
                                         />
                                     ))}
                                 </div>

--- a/sections/about/about.tsx
+++ b/sections/about/about.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Card,
 } from "@prasheel/ui";
+import { trackClick } from "@/lib/gtag";
 
 interface Interest {
   title: string;
@@ -76,7 +77,20 @@ const About = ({
       case "blogging":
         return (
           <Button variant="default" size="sm" asChild>
-            <Link href="/blog" className="no-underline">
+            <Link
+              href="/blog"
+              className="no-underline"
+              onClick={() =>
+                trackClick({
+                  section: "interests",
+                  content_type: "cta",
+                  item_id: "view_blog",
+                  item_name: tInterests("viewBlog"),
+                  link_url: "/blog",
+                  link_text: tInterests("viewBlog"),
+                })
+              }
+            >
               {tInterests("viewBlog")}
             </Link>
           </Button>
@@ -84,7 +98,20 @@ const About = ({
       case "photography":
         return (
           <Button variant="default" size="sm" asChild>
-            <Link href="/photo-gallery" className="no-underline">
+            <Link
+              href="/photo-gallery"
+              className="no-underline"
+              onClick={() =>
+                trackClick({
+                  section: "interests",
+                  content_type: "cta",
+                  item_id: "view_gallery",
+                  item_name: tInterests("viewGallery"),
+                  link_url: "/photo-gallery",
+                  link_text: tInterests("viewGallery"),
+                })
+              }
+            >
               {tInterests("viewGallery")}
             </Link>
           </Button>
@@ -97,6 +124,16 @@ const About = ({
               target="_blank"
               rel="noopener noreferrer"
               className="no-underline"
+              onClick={() =>
+                trackClick({
+                  section: "interests",
+                  content_type: "profile",
+                  item_id: "github",
+                  item_name: "GitHub",
+                  link_url: "https://github.com/ps011",
+                  link_text: tInterests("viewGithub"),
+                })
+              }
             >
               {tInterests("viewGithub")}
             </Link>

--- a/sections/banner/banner.tsx
+++ b/sections/banner/banner.tsx
@@ -10,6 +10,7 @@ import {
 } from "framer-motion";
 import { ArrowUpRight } from "lucide-react";
 import { Button } from "@prasheel/ui";
+import { trackClick } from "@/lib/gtag";
 import { useTranslations } from "next-intl";
 
 interface BannerProps {
@@ -174,6 +175,16 @@ const Banner = ({
                 target="_blank"
                 rel="noopener noreferrer"
                 className="no-underline"
+                onClick={() =>
+                  trackClick({
+                    section: "banner",
+                    content_type: "cta",
+                    item_id: "banner_cta",
+                    item_name: translatedCtaLabel,
+                    link_url: ctaUrl,
+                    link_text: translatedCtaLabel,
+                  })
+                }
               >
                 {translatedCtaLabel}
                 <ArrowUpRight className="size-4 shrink-0" aria-hidden />

--- a/sections/blog-index/blog-index.tsx
+++ b/sections/blog-index/blog-index.tsx
@@ -7,6 +7,7 @@ import BlogCard from "../../components/blog-card";
 import { Button } from "@prasheel/ui";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { trackSearch, trackSelectItem } from "@/lib/gtag";
 import type { BlogCard as BlogCardData } from "../../interfaces/blog";
 
 const ALL_TAG = "all";
@@ -44,6 +45,24 @@ const BlogIndex = ({ blogs }: { blogs: BlogCardData[] }) => {
     });
   }, [blogs, deferredQuery, activeTag]);
 
+  const handleSearchChange = (nextQuery: string) => {
+    setQuery(nextQuery);
+    trackSearch({
+      section: "blog_index",
+      search_term: nextQuery.trim(),
+    });
+  };
+
+  const handleTagChange = (tag: string) => {
+    setActiveTag(tag);
+    trackSelectItem({
+      section: "blog_index",
+      content_type: "tag",
+      item_id: tag,
+      item_name: tag === ALL_TAG ? t("allTag") : tag,
+    });
+  };
+
   return (
     <div className="min-h-screen bg-background">
       <main className="container mx-auto px-6 py-12">
@@ -69,7 +88,7 @@ const BlogIndex = ({ blogs }: { blogs: BlogCardData[] }) => {
               id="blog-search"
               type="search"
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              onChange={(e) => handleSearchChange(e.target.value)}
               placeholder={t("searchPlaceholder")}
               className="pl-10"
             />
@@ -82,7 +101,7 @@ const BlogIndex = ({ blogs }: { blogs: BlogCardData[] }) => {
               key={ALL_TAG}
               variant={activeTag === ALL_TAG ? "default" : "neutral"}
               size="sm"
-              onClick={() => setActiveTag(ALL_TAG)}
+              onClick={() => handleTagChange(ALL_TAG)}
             >
               {t("allTag")}
             </Button>
@@ -91,7 +110,7 @@ const BlogIndex = ({ blogs }: { blogs: BlogCardData[] }) => {
                 key={tag}
                 variant={activeTag === tag ? "default" : "neutral"}
                 size="sm"
-                onClick={() => setActiveTag(tag)}
+                onClick={() => handleTagChange(tag)}
               >
                 {tag}
               </Button>

--- a/sections/blog/blog.tsx
+++ b/sections/blog/blog.tsx
@@ -13,6 +13,7 @@ import {
   type CarouselApi,
 } from "@prasheel/ui";
 import { cn } from "@/lib/utils";
+import { trackSelectItem } from "@/lib/gtag";
 import { BlogCard as BlogCardData } from "../../interfaces/blog";
 
 const kebabCaseToSentenceCase = (str: string) =>
@@ -77,6 +78,15 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
     };
   }, [api, onSelect]);
 
+  const trackCarouselControl = (action: string, index?: number) => {
+    trackSelectItem({
+      section: "home_blog_carousel",
+      content_type: "carousel",
+      item_id: index === undefined ? action : `${action}_${index + 1}`,
+      item_name: index === undefined ? action : `Slide ${index + 1}`,
+    });
+  };
+
   return (
     <div>
       <Carousel opts={{ align: "start", loop: true }} setApi={setApi}>
@@ -101,7 +111,10 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
           <Button
             variant="noShadow"
             size="icon"
-            onClick={() => api?.scrollPrev()}
+            onClick={() => {
+              trackCarouselControl("previous");
+              api?.scrollPrev();
+            }}
             disabled={!canScrollPrev}
             aria-label={t("prevSlide")}
             className="h-9 w-9 shrink-0 rounded-base border-2 border-border disabled:opacity-40"
@@ -113,7 +126,10 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
             {Array.from({ length: count }).map((_, i) => (
               <button
                 key={i}
-                onClick={() => api?.scrollTo(i)}
+                onClick={() => {
+                  trackCarouselControl("dot", i);
+                  api?.scrollTo(i);
+                }}
                 aria-label={t("goToSlide", { number: i + 1 })}
                 className={cn(
                   "h-2.5 rounded-full border-2 border-border shadow-shadow-sm transition-all duration-200",
@@ -126,7 +142,10 @@ function BlogCarousel({ blogs }: { blogs: BlogCardData[] }) {
           <Button
             variant="noShadow"
             size="icon"
-            onClick={() => api?.scrollNext()}
+            onClick={() => {
+              trackCarouselControl("next");
+              api?.scrollNext();
+            }}
             disabled={!canScrollNext}
             aria-label={t("nextSlide")}
             className="h-9 w-9 shrink-0 rounded-base border-2 border-border disabled:opacity-40"

--- a/sections/footer/footer.tsx
+++ b/sections/footer/footer.tsx
@@ -10,6 +10,7 @@ import {
 import Profile from "../../components/profile/profile";
 import { useTranslations } from "next-intl";
 import { LanguageSwitcher } from "../../components/language-switcher/language-switcher";
+import { trackClick } from "@/lib/gtag";
 
 const Footer = ({
   profiles,
@@ -64,6 +65,16 @@ const Footer = ({
             target="_blank"
             rel="noreferrer"
             className="underline hover:no-underline"
+            onClick={() =>
+              trackClick({
+                section: "footer",
+                content_type: "profile",
+                item_id: "linkedin",
+                item_name: "LinkedIn",
+                link_url: "https://linkedin.com/in/ps011",
+                link_text: "Prasheel",
+              })
+            }
           >
             Prasheel
           </a>
@@ -75,6 +86,16 @@ const Footer = ({
             target="_blank"
             rel="noreferrer"
             className="underline hover:no-underline"
+            onClick={() =>
+              trackClick({
+                section: "footer",
+                content_type: "legal",
+                item_id: "license",
+                item_name: t("license"),
+                link_url: "https://github.com/ps011/ps11/LICENSE.md",
+                link_text: t("license"),
+              })
+            }
           >
             {t("license")}
           </a>


### PR DESCRIPTION
## Summary
- migrate Google Analytics from the legacy UA ID to GA4 using G-57NC87VXFC with NEXT_PUBLIC_GA_MEASUREMENT_ID override support
- load GA through next/script and centralize guarded page/event tracking in lib/gtag
- add focused interaction events across nav, CTAs, profile links, blog, language, and gallery flows

## Test Plan
- npm run lint
- npm test
- npm run build

Note: build exits 0 but still prints the existing ENVIRONMENT_FALLBACK message during static generation.