### PR TITLE
[codex] add Keku robot crab post

### DIFF
--- a/__tests__/lib/data.test.ts
+++ b/__tests__/lib/data.test.ts
@@ -1,5 +1,10 @@
 import { getSiteData, getAboutData, getBlogs, getBlogByLink, getGalleryItems } from "../../lib/data";
 
+const KEKU_POST_URL =
+  "https://ps11.hashnode.dev/i-built-a-robot-crab-named-keku-here-s-everything-that-went-wrong-and-right";
+const KEKU_BANNER_URL =
+  "https://res.cloudinary.com/designu/image/upload/v1780126242/Banners/aa3797fd-674f-4225-b7ab-47e171791523.png";
+
 describe("lib/data", () => {
   describe("getSiteData", () => {
     it("returns site data from data/site.json", async () => {
@@ -48,6 +53,20 @@ describe("lib/data", () => {
         type: "experiments",
       });
     });
+
+    it("includes the Keku robot crab post as a visible experiment", async () => {
+      const blogs = await getBlogs();
+      const experiment = blogs.find(
+        (blog) => blog.link === KEKU_POST_URL,
+      );
+
+      expect(experiment).toMatchObject({
+        title: "I Built a Robot Crab Named Keku",
+        thumbnail: KEKU_BANNER_URL,
+        hidden: false,
+        type: "experiments",
+      });
+    });
   });
 
   describe("getBlogByLink", () => {
@@ -61,6 +80,16 @@ describe("lib/data", () => {
     it("returns null for non-existent link", async () => {
       const blog = await getBlogByLink("does-not-exist");
       expect(blog).toBeNull();
+    });
+
+    it("includes banner metadata for the Keku robot crab post", async () => {
+      const blog = await getBlogByLink(KEKU_POST_URL);
+
+      expect(blog).toMatchObject({
+        title: "I Built a Robot Crab Named Keku",
+        banner: KEKU_BANNER_URL,
+        thumbnail: KEKU_BANNER_URL,
+      });
     });
   });
 

--- a/data/blogs.json
+++ b/data/blogs.json
@@ -278,6 +278,19 @@
     "link": "https://ps011.github.io/buying-decision-maker/"
   },
   {
+    "title": "I Built a Robot Crab Named Keku",
+    "shortDescription": "Everything that went wrong and right while building Keku, a robot crab experiment.",
+    "thumbnail": "https://res.cloudinary.com/designu/image/upload/v1780126242/Banners/aa3797fd-674f-4225-b7ab-47e171791523.png",
+    "banner": "https://res.cloudinary.com/designu/image/upload/v1780126242/Banners/aa3797fd-674f-4225-b7ab-47e171791523.png",
+    "author": "Prasheel Soni",
+    "profileLink": "https://github.com/ps011",
+    "hidden": false,
+    "tags": "robotics, hardware, diy, experiments",
+    "date": "2026-05-30T00:00:00.000Z",
+    "type": "experiments",
+    "link": "https://ps11.hashnode.dev/i-built-a-robot-crab-named-keku-here-s-everything-that-went-wrong-and-right"
+  },
+  {
     "title": "Understand and Build Your Personal AI with 'RAG Builder'",
     "shortDescription": "RAG Builder, a simple, local-first system that turns your scattered thoughts into a powerful, queryable knowledge base.",
     "banner": "https://res.cloudinary.com/designu/image/upload/v1759265237/images/RAG-builder/Gemini_Generated_Image_h2r4y2h2r4y2h2r4.png",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ module.exports = [
       "public/**/*",
       "node_modules/**/*",
       ".next/**/*",
+      ".worktrees/**/*",
       ".vercel/**/*",
       "out/**/*",
       "build/**/*",


### PR DESCRIPTION
## Summary

- Adds the new Hashnode post about the Keku robot crab as a visible `experiments` item on the portfolio homepage.
- Adds the provided Cloudinary image as both `banner` and `thumbnail` for the Keku entry.
- Adds focused data-layer tests to guard that the Keku experiment entry remains visible and keeps its image metadata.
- Updates the ESLint ignore list so existing local worktree build artifacts are not linted by the pre-commit hook.

## Validation

- `npm run lint:fix` passed.
- `npm test -- __tests__/lib/data.test.ts` passed: 9 tests.
- `npm test` passed: 13 suites, 90 tests.
- Commit was amended with hooks enabled.