### PR TITLE
[codex] add Budapest photo album

### DIFF
--- a/__tests__/lib/data.test.ts
+++ b/__tests__/lib/data.test.ts
@@ -4,6 +4,13 @@ const KEKU_POST_URL =
   "https://ps11.hashnode.dev/i-built-a-robot-crab-named-keku-here-s-everything-that-went-wrong-and-right";
 const KEKU_BANNER_URL =
   "https://res.cloudinary.com/designu/image/upload/v1780126242/Banners/aa3797fd-674f-4225-b7ab-47e171791523.png";
+const BUDAPEST_PHOTO_URLS = [
+  "https://res.cloudinary.com/designu/image/upload/v1780128476/Photo%20Gallery/Budapest/PXL_20260221_184503196.jpg",
+  "https://res.cloudinary.com/designu/image/upload/v1780128471/Photo%20Gallery/Budapest/PXL_20260220_152945079_2.jpg",
+  "https://res.cloudinary.com/designu/image/upload/v1780128471/Photo%20Gallery/Budapest/IMG_3182.jpg",
+  "https://res.cloudinary.com/designu/image/upload/v1780128469/Photo%20Gallery/Budapest/PXL_20260222_113133273_2.jpg",
+  "https://res.cloudinary.com/designu/image/upload/v1780128468/Photo%20Gallery/Budapest/PXL_20260223_104933408.jpg",
+];
 
 describe("lib/data", () => {
   describe("getSiteData", () => {
@@ -102,6 +109,25 @@ describe("lib/data", () => {
       expect(first).toHaveProperty("id");
       expect(first).toHaveProperty("src");
       expect(first).toHaveProperty("category");
+    });
+
+    it("includes the Budapest photo album", async () => {
+      const items = await getGalleryItems();
+      const budapestItems = items.filter((item) => item.category === "Hungary");
+
+      expect(budapestItems).toHaveLength(BUDAPEST_PHOTO_URLS.length);
+      expect(budapestItems.map((item) => item.id)).toEqual([
+        "Hungary-0",
+        "Hungary-1",
+        "Hungary-2",
+        "Hungary-3",
+        "Hungary-4",
+      ]);
+      expect(budapestItems.map((item) => item.location)).toEqual(
+        Array(BUDAPEST_PHOTO_URLS.length).fill("Budapest"),
+      );
+      expect(budapestItems.map((item) => item.src)).toEqual(BUDAPEST_PHOTO_URLS);
+      expect(budapestItems.map((item) => item.thumb)).toEqual(BUDAPEST_PHOTO_URLS);
     });
   });
 

--- a/data/gallery.json
+++ b/data/gallery.json
@@ -206,5 +206,45 @@
     "caption": "",
     "category": "Croatia",
     "location": "Croatia"
+  },
+  {
+    "id": "Hungary-0",
+    "src": "https://res.cloudinary.com/designu/image/upload/v1780128476/Photo%20Gallery/Budapest/PXL_20260221_184503196.jpg",
+    "thumb": "https://res.cloudinary.com/designu/image/upload/v1780128476/Photo%20Gallery/Budapest/PXL_20260221_184503196.jpg",
+    "caption": "",
+    "category": "Hungary",
+    "location": "Budapest"
+  },
+  {
+    "id": "Hungary-1",
+    "src": "https://res.cloudinary.com/designu/image/upload/v1780128471/Photo%20Gallery/Budapest/PXL_20260220_152945079_2.jpg",
+    "thumb": "https://res.cloudinary.com/designu/image/upload/v1780128471/Photo%20Gallery/Budapest/PXL_20260220_152945079_2.jpg",
+    "caption": "",
+    "category": "Hungary",
+    "location": "Budapest"
+  },
+  {
+    "id": "Hungary-2",
+    "src": "https://res.cloudinary.com/designu/image/upload/v1780128471/Photo%20Gallery/Budapest/IMG_3182.jpg",
+    "thumb": "https://res.cloudinary.com/designu/image/upload/v1780128471/Photo%20Gallery/Budapest/IMG_3182.jpg",
+    "caption": "",
+    "category": "Hungary",
+    "location": "Budapest"
+  },
+  {
+    "id": "Hungary-3",
+    "src": "https://res.cloudinary.com/designu/image/upload/v1780128469/Photo%20Gallery/Budapest/PXL_20260222_113133273_2.jpg",
+    "thumb": "https://res.cloudinary.com/designu/image/upload/v1780128469/Photo%20Gallery/Budapest/PXL_20260222_113133273_2.jpg",
+    "caption": "",
+    "category": "Hungary",
+    "location": "Budapest"
+  },
+  {
+    "id": "Hungary-4",
+    "src": "https://res.cloudinary.com/designu/image/upload/v1780128468/Photo%20Gallery/Budapest/PXL_20260223_104933408.jpg",
+    "thumb": "https://res.cloudinary.com/designu/image/upload/v1780128468/Photo%20Gallery/Budapest/PXL_20260223_104933408.jpg",
+    "caption": "",
+    "category": "Hungary",
+    "location": "Budapest"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds five Budapest photos to the photo gallery data under the Hungary category.
- Adds data-layer coverage to verify the Budapest album IDs, URLs, thumbs, and location.

## Validation
- `npm test` - 91 passed
- `npm run build` - exit 0; existing `ENVIRONMENT_FALLBACK` message still appears during static generation
