### PR TITLE
[codex] add youtube rss section

### DIFF
--- a/__tests__/pages/index.test.tsx
+++ b/__tests__/pages/index.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import IndexPage from "../../pages/index";
+import IndexPage, { getStaticProps } from "../../pages/index";
 import { BlogCard } from "../../interfaces/blog";
+import type { YouTubeVideo } from "../../interfaces/youtube";
+import { getAboutData, getBlogs, getSiteData } from "../../lib/data";
+import { getYouTubeVideos } from "../../lib/youtube";
 
 jest.mock("../../sections/banner/banner", () => ({
   __esModule: true,
@@ -22,8 +25,23 @@ jest.mock("../../sections/blog/blog", () => ({
   default: () => <section data-testid="blog" />,
 }));
 
+jest.mock("../../sections/youtube/youtube", () => ({
+  __esModule: true,
+  default: () => <section data-testid="youtube" />,
+}));
+
 jest.mock("../../sections/map/map", () => ({
   Map: () => <section data-testid="map" />,
+}));
+
+jest.mock("../../lib/data", () => ({
+  getSiteData: jest.fn(),
+  getAboutData: jest.fn(),
+  getBlogs: jest.fn(),
+}));
+
+jest.mock("../../lib/youtube", () => ({
+  getYouTubeVideos: jest.fn(),
 }));
 
 const mockBannerData = { headline: "Hello World" };
@@ -47,19 +65,44 @@ const mockBlogs: BlogCard[] = [
   },
 ];
 
+const mockYouTubeVideos: YouTubeVideo[] = [
+  {
+    id: "ndefUGEmywM",
+    title: "VIVID VILNIUS EPISODE 02",
+    url: "https://www.youtube.com/watch?v=ndefUGEmywM",
+    thumbnailUrl: "https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg",
+    publishedAt: "2026-04-27T15:24:04+00:00",
+  },
+];
+
 describe("IndexPage", () => {
+  beforeEach(() => {
+    jest.mocked(getSiteData).mockResolvedValue({
+      banner: mockBannerData,
+    } as any);
+    jest.mocked(getAboutData).mockResolvedValue(mockAboutData as any);
+    jest.mocked(getBlogs).mockResolvedValue(mockBlogs);
+    jest.mocked(getYouTubeVideos).mockResolvedValue(mockYouTubeVideos);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders all sections when full data is provided", () => {
     render(
       <IndexPage
         bannerData={mockBannerData}
         aboutData={mockAboutData}
         blogs={mockBlogs}
+        youtubeVideos={mockYouTubeVideos}
       />,
     );
     expect(screen.getByTestId("banner")).toBeInTheDocument();
     expect(screen.getByTestId("about")).toBeInTheDocument();
     expect(screen.getByTestId("experience")).toBeInTheDocument();
     expect(screen.getByTestId("blog")).toBeInTheDocument();
+    expect(screen.getByTestId("youtube")).toBeInTheDocument();
     expect(screen.getByTestId("map")).toBeInTheDocument();
   });
 
@@ -69,6 +112,7 @@ describe("IndexPage", () => {
         bannerData={null}
         aboutData={mockAboutData}
         blogs={mockBlogs}
+        youtubeVideos={mockYouTubeVideos}
       />,
     );
     expect(screen.queryByTestId("banner")).not.toBeInTheDocument();
@@ -80,6 +124,7 @@ describe("IndexPage", () => {
         bannerData={mockBannerData}
         aboutData={{ ...mockAboutData, experience: [] }}
         blogs={mockBlogs}
+        youtubeVideos={mockYouTubeVideos}
       />,
     );
     expect(screen.queryByTestId("experience")).not.toBeInTheDocument();
@@ -91,6 +136,7 @@ describe("IndexPage", () => {
         bannerData={mockBannerData}
         aboutData={{ ...mockAboutData, countriesVisited: undefined }}
         blogs={mockBlogs}
+        youtubeVideos={mockYouTubeVideos}
       />,
     );
     expect(screen.queryByTestId("map")).not.toBeInTheDocument();
@@ -102,8 +148,23 @@ describe("IndexPage", () => {
         bannerData={mockBannerData}
         aboutData={mockAboutData}
         blogs={mockBlogs}
+        youtubeVideos={mockYouTubeVideos}
       />,
     );
     expect(screen.getByTestId("blog")).toBeInTheDocument();
+  });
+
+  it("loads YouTube videos in static props", async () => {
+    const result = await getStaticProps({ locale: "en" } as any);
+
+    expect(getYouTubeVideos).toHaveBeenCalledWith(6);
+    expect(result).toEqual(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          youtubeVideos: mockYouTubeVideos,
+        }),
+        revalidate: 3600,
+      }),
+    );
   });
 });

--- a/docs/superpowers/plans/2026-06-27-youtube-rss.md
+++ b/docs/superpowers/plans/2026-06-27-youtube-rss.md
@@ -1,0 +1,140 @@
+# YouTube RSS Homepage Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a resilient homepage section that automatically shows recent YouTube videos from the channel RSS feed.
+
+**Architecture:** A server-only helper builds the feed URL from the canonical channel ID, fetches RSS during `getStaticProps`, parses entries into `YouTubeVideo`, and returns `[]` on failure. A homepage section renders those videos using the existing `Section`, carousel, and `@prasheel/ui` card/button primitives.
+
+**Tech Stack:** Next.js Pages Router, TypeScript, Jest, React Testing Library, YouTube Atom RSS, `@prasheel/ui`.
+
+## Global Constraints
+
+- Channel ID is `UCbcnZGYObyzOZFe3elbyF9w`.
+- Do not use the YouTube Data API or a Google Cloud project.
+- RSS errors must not fail static generation.
+- Do not import server-only helpers into client components.
+- Reuse `@prasheel/ui` primitives for card/button UI.
+- Follow TDD: write failing tests before production code.
+
+---
+
+### Task 1: RSS Data Helper
+
+**Files:**
+- Create: `interfaces/youtube.ts`
+- Create: `lib/youtube.ts`
+- Test: `lib/youtube.test.ts`
+
+**Interfaces:**
+- Produces: `YouTubeVideo` with `{ id: string; title: string; url: string; thumbnailUrl: string; publishedAt: string }`
+- Produces: `YOUTUBE_CHANNEL_ID = "UCbcnZGYObyzOZFe3elbyF9w"`
+- Produces: `getYouTubeFeedUrl(channelId?: string): string`
+- Produces: `parseYouTubeFeed(xml: string, limit?: number): YouTubeVideo[]`
+- Produces: `getYouTubeVideos(limit?: number): Promise<YouTubeVideo[]>`
+
+- [ ] **Step 1: Write failing parser and fetch tests**
+
+Create `lib/youtube.test.ts` with tests that expect parsed video data, limited results, and empty fallback when `fetch` rejects.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- lib/youtube.test.ts`
+
+Expected: FAIL because `./youtube` does not exist.
+
+- [ ] **Step 3: Add interface and minimal implementation**
+
+Create `interfaces/youtube.ts` and `lib/youtube.ts`. Implement XML parsing with `DOMParser`, feed URL construction, fetch status validation, and `[]` fallback.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- lib/youtube.test.ts`
+
+Expected: PASS.
+
+### Task 2: YouTube Section UI
+
+**Files:**
+- Create: `sections/youtube/youtube.tsx`
+- Test: `sections/youtube/youtube.test.tsx`
+
+**Interfaces:**
+- Consumes: `YouTubeVideo[]`
+- Produces: default React component `YouTube({ videos }: { videos: YouTubeVideo[] })`
+
+- [ ] **Step 1: Write failing section tests**
+
+Create `sections/youtube/youtube.test.tsx` with tests that empty videos render no section and populated videos render a `Videos` heading plus external YouTube links.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- sections/youtube/youtube.test.tsx`
+
+Expected: FAIL because the section component does not exist.
+
+- [ ] **Step 3: Implement section**
+
+Create a client component that uses `Section`, `Carousel`, `CarouselContent`, `CarouselItem`, `Card`, `Button`, `Image`, and `Link`. Render nothing for empty videos.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- sections/youtube/youtube.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Homepage Integration
+
+**Files:**
+- Modify: `pages/index.tsx`
+- Test: `__tests__/pages/index.test.tsx`
+
+**Interfaces:**
+- Consumes: `getYouTubeVideos(6): Promise<YouTubeVideo[]>`
+- Consumes: `YouTube` section component
+
+- [ ] **Step 1: Update failing page tests**
+
+Extend the homepage page tests to mock `getYouTubeVideos` and expect `getStaticProps` to expose a `youtubeVideos` prop.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- __tests__/pages/index.test.tsx`
+
+Expected: FAIL because `getYouTubeVideos` is not used by `getStaticProps`.
+
+- [ ] **Step 3: Wire homepage data and render**
+
+Import `getYouTubeVideos`, include it in the `Promise.all`, add `youtubeVideos` to props, and render `<YouTube videos={youtubeVideos} />` after the blog section.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `npm test -- lib/youtube.test.ts sections/youtube/youtube.test.tsx __tests__/pages/index.test.tsx`
+
+Expected: PASS.
+
+### Task 4: Final Verification
+
+**Files:**
+- No additional files.
+
+**Interfaces:**
+- Verifies all previous tasks.
+
+- [ ] **Step 1: Run lint**
+
+Run: `npm run lint`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run production build**
+
+Run: `npm run build`
+
+Expected: PASS.

--- a/docs/superpowers/specs/2026-06-27-youtube-rss-design.md
+++ b/docs/superpowers/specs/2026-06-27-youtube-rss-design.md
@@ -1,0 +1,44 @@
+# YouTube RSS Homepage Section Design
+
+## Goal
+
+Add an automatic homepage section that shows recent videos from Prasheel Soni's YouTube channel without requiring a Google Cloud project or YouTube Data API key.
+
+## Requirements
+
+- Use YouTube's public Atom RSS feed.
+- Store the canonical channel ID, `UCbcnZGYObyzOZFe3elbyF9w`, not the handle `@PrasheelSoni11`.
+- Build the feed URL server-side as `https://www.youtube.com/feeds/videos.xml?channel_id=UCbcnZGYObyzOZFe3elbyF9w`.
+- Fetch and parse the feed only from server-side homepage data loading.
+- Render the section only when videos are available.
+- If the feed request fails, the portfolio must still build and the section must be hidden.
+- Reuse the existing homepage section style and `@prasheel/ui` primitives.
+
+## Architecture
+
+Add a small server-only YouTube module that fetches the RSS feed and parses entries into a portfolio-friendly `YouTubeVideo` interface. The homepage will load those videos in `getStaticProps` alongside the existing site, about, and blog data, and pass them into a new `sections/youtube/youtube.tsx` component.
+
+The UI will follow the existing blog section pattern: a `Section` wrapper with a carousel of cards. Cards will use `@prasheel/ui` `Card` and `Button` primitives directly, so no design-system change is needed.
+
+## Data Shape
+
+```ts
+interface YouTubeVideo {
+  id: string;
+  title: string;
+  url: string;
+  thumbnailUrl: string;
+  publishedAt: string;
+}
+```
+
+## Error Handling
+
+The RSS fetch helper catches network, HTTP, and parse failures and returns an empty array. This keeps static generation resilient when YouTube is unavailable.
+
+## Testing
+
+- Unit-test RSS parsing from a representative Atom XML sample.
+- Unit-test fetch failure fallback to an empty array.
+- Component-test that the section renders video links when videos exist and renders nothing for an empty array.
+- Page-test that homepage data loading passes YouTube videos into the page component.

--- a/interfaces/youtube.ts
+++ b/interfaces/youtube.ts
@@ -1,0 +1,7 @@
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  url: string;
+  thumbnailUrl: string;
+  publishedAt: string;
+}

--- a/lib/youtube.test.ts
+++ b/lib/youtube.test.ts
@@ -1,0 +1,134 @@
+import {
+  getYouTubeFeedUrl,
+  getYouTubeVideos,
+  parseYouTubeFeed,
+  YOUTUBE_CHANNEL_ID,
+} from "./youtube";
+
+const feedXml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+  <title>Prasheel Soni</title>
+  <entry>
+    <id>yt:video:ndefUGEmywM</id>
+    <yt:videoId>ndefUGEmywM</yt:videoId>
+    <title>VIVID VILNIUS EPISODE 02: Teeth on a Wall, Castle Views, Lost Dipsi &amp; Vegan Feasts!</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=ndefUGEmywM"/>
+    <published>2026-04-27T15:24:04+00:00</published>
+    <media:group>
+      <media:thumbnail url="https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg" width="480" height="360"/>
+    </media:group>
+  </entry>
+  <entry>
+    <id>yt:video:l82IxaZMob0</id>
+    <yt:videoId>l82IxaZMob0</yt:videoId>
+    <title>EPISODE 01: Cathedrals, Curries &amp; Old Town Charms</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=l82IxaZMob0"/>
+    <published>2026-04-19T09:08:08+00:00</published>
+    <media:group>
+      <media:thumbnail url="https://i1.ytimg.com/vi/l82IxaZMob0/hqdefault.jpg" width="480" height="360"/>
+    </media:group>
+  </entry>
+</feed>`;
+
+describe("youtube RSS helpers", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("builds the feed URL from the canonical channel ID", () => {
+    expect(YOUTUBE_CHANNEL_ID).toBe("UCbcnZGYObyzOZFe3elbyF9w");
+    expect(getYouTubeFeedUrl()).toBe(
+      "https://www.youtube.com/feeds/videos.xml?channel_id=UCbcnZGYObyzOZFe3elbyF9w",
+    );
+  });
+
+  it("parses YouTube Atom entries into video cards", () => {
+    expect(parseYouTubeFeed(feedXml)).toEqual([
+      {
+        id: "ndefUGEmywM",
+        title:
+          "VIVID VILNIUS EPISODE 02: Teeth on a Wall, Castle Views, Lost Dipsi & Vegan Feasts!",
+        url: "https://www.youtube.com/watch?v=ndefUGEmywM",
+        thumbnailUrl: "https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg",
+        publishedAt: "2026-04-27T15:24:04+00:00",
+      },
+      {
+        id: "l82IxaZMob0",
+        title: "EPISODE 01: Cathedrals, Curries & Old Town Charms",
+        url: "https://www.youtube.com/watch?v=l82IxaZMob0",
+        thumbnailUrl: "https://i1.ytimg.com/vi/l82IxaZMob0/hqdefault.jpg",
+        publishedAt: "2026-04-19T09:08:08+00:00",
+      },
+    ]);
+  });
+
+  it("parses feeds when DOMParser is unavailable in Node", () => {
+    const originalDOMParser = global.DOMParser;
+    Object.defineProperty(global, "DOMParser", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      expect(parseYouTubeFeed(feedXml, 1)).toEqual([
+        {
+          id: "ndefUGEmywM",
+          title:
+            "VIVID VILNIUS EPISODE 02: Teeth on a Wall, Castle Views, Lost Dipsi & Vegan Feasts!",
+          url: "https://www.youtube.com/watch?v=ndefUGEmywM",
+          thumbnailUrl: "https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg",
+          publishedAt: "2026-04-27T15:24:04+00:00",
+        },
+      ]);
+    } finally {
+      Object.defineProperty(global, "DOMParser", {
+        configurable: true,
+        value: originalDOMParser,
+      });
+    }
+  });
+
+  it("limits parsed videos", () => {
+    expect(parseYouTubeFeed(feedXml, 1)).toHaveLength(1);
+  });
+
+  it("returns an empty list when the feed request fails", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network down"));
+
+    await expect(getYouTubeVideos()).resolves.toEqual([]);
+  });
+
+  it("returns an empty list when YouTube responds with an error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: jest.fn(),
+    });
+
+    await expect(getYouTubeVideos()).resolves.toEqual([]);
+  });
+
+  it("fetches and parses the RSS feed", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(feedXml),
+    });
+
+    await expect(getYouTubeVideos(1)).resolves.toEqual([
+      {
+        id: "ndefUGEmywM",
+        title:
+          "VIVID VILNIUS EPISODE 02: Teeth on a Wall, Castle Views, Lost Dipsi & Vegan Feasts!",
+        url: "https://www.youtube.com/watch?v=ndefUGEmywM",
+        thumbnailUrl: "https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg",
+        publishedAt: "2026-04-27T15:24:04+00:00",
+      },
+    ]);
+    expect(global.fetch).toHaveBeenCalledWith(getYouTubeFeedUrl(), {
+      headers: { accept: "application/atom+xml, application/xml, text/xml" },
+    });
+  });
+});

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,0 +1,114 @@
+import type { YouTubeVideo } from "../interfaces/youtube";
+
+export const YOUTUBE_CHANNEL_ID = "UCbcnZGYObyzOZFe3elbyF9w";
+
+const YOUTUBE_FEED_BASE_URL = "https://www.youtube.com/feeds/videos.xml";
+const DEFAULT_VIDEO_LIMIT = 6;
+
+const getText = (entry: Element, tagName: string) =>
+  entry.getElementsByTagName(tagName)[0]?.textContent?.trim() ?? "";
+
+const getAlternateUrl = (entry: Element) => {
+  const links = Array.from(entry.getElementsByTagName("link"));
+  return (
+    links.find((link) => link.getAttribute("rel") === "alternate") ??
+    links[0]
+  )?.getAttribute("href") ?? "";
+};
+
+const getThumbnailUrl = (entry: Element) =>
+  entry.getElementsByTagName("media:thumbnail")[0]?.getAttribute("url") ?? "";
+
+const decodeXmlEntities = (value: string) =>
+  value.replace(/&(#x?[0-9a-fA-F]+|amp|lt|gt|quot|apos);/g, (match, entity) => {
+    if (entity === "amp") return "&";
+    if (entity === "lt") return "<";
+    if (entity === "gt") return ">";
+    if (entity === "quot") return "\"";
+    if (entity === "apos") return "'";
+    if (entity.startsWith("#x")) return String.fromCodePoint(parseInt(entity.slice(2), 16));
+    if (entity.startsWith("#")) return String.fromCodePoint(parseInt(entity.slice(1), 10));
+    return match;
+  });
+
+const getXmlText = (entry: string, tagName: string) => {
+  const match = entry.match(
+    new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tagName}>`),
+  );
+  return decodeXmlEntities(match?.[1]?.trim() ?? "");
+};
+
+const getXmlAttribute = (entry: string, tagName: string, attribute: string) => {
+  const match = entry.match(
+    new RegExp(`<${tagName}\\b[^>]*\\b${attribute}="([^"]*)"`, "i"),
+  );
+  return decodeXmlEntities(match?.[1] ?? "");
+};
+
+const getXmlAlternateUrl = (entry: string) => {
+  const match = entry.match(
+    /<link\b(?=[^>]*\brel="alternate")[^>]*\bhref="([^"]*)"/i,
+  );
+  return decodeXmlEntities(match?.[1] ?? "");
+};
+
+const parseYouTubeFeedWithRegex = (
+  xml: string,
+  limit: number,
+): YouTubeVideo[] =>
+  Array.from(xml.matchAll(/<entry\b[^>]*>([\s\S]*?)<\/entry>/g))
+    .map(([, entry]) => ({
+      id: getXmlText(entry, "yt:videoId"),
+      title: getXmlText(entry, "title"),
+      url: getXmlAlternateUrl(entry),
+      thumbnailUrl: getXmlAttribute(entry, "media:thumbnail", "url"),
+      publishedAt: getXmlText(entry, "published"),
+    }))
+    .filter((video) => video.id && video.title && video.url)
+    .slice(0, limit);
+
+export function getYouTubeFeedUrl(channelId = YOUTUBE_CHANNEL_ID) {
+  const url = new URL(YOUTUBE_FEED_BASE_URL);
+  url.searchParams.set("channel_id", channelId);
+  return url.toString();
+}
+
+export function parseYouTubeFeed(
+  xml: string,
+  limit = DEFAULT_VIDEO_LIMIT,
+): YouTubeVideo[] {
+  if (typeof DOMParser !== "function") {
+    return parseYouTubeFeedWithRegex(xml, limit);
+  }
+
+  const document = new DOMParser().parseFromString(xml, "application/xml");
+  const parserError = document.getElementsByTagName("parsererror")[0];
+  if (parserError) return [];
+
+  return Array.from(document.getElementsByTagName("entry"))
+    .map((entry) => ({
+      id: getText(entry, "yt:videoId"),
+      title: getText(entry, "title"),
+      url: getAlternateUrl(entry),
+      thumbnailUrl: getThumbnailUrl(entry),
+      publishedAt: getText(entry, "published"),
+    }))
+    .filter((video) => video.id && video.title && video.url)
+    .slice(0, limit);
+}
+
+export async function getYouTubeVideos(
+  limit = DEFAULT_VIDEO_LIMIT,
+): Promise<YouTubeVideo[]> {
+  try {
+    const response = await fetch(getYouTubeFeedUrl(), {
+      headers: { accept: "application/atom+xml, application/xml, text/xml" },
+    });
+
+    if (!response.ok) return [];
+
+    return parseYouTubeFeed(await response.text(), limit);
+  } catch {
+    return [];
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,10 @@ module.exports = {
         protocol: "https",
         hostname: "cdn.hashnode.com",
       },
+      {
+        protocol: "https",
+        hostname: "**.ytimg.com",
+      },
     ],
   },
   compiler: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,15 +2,19 @@ import Banner from "../sections/banner/banner";
 import About from "../sections/about/about";
 import Experience from "../sections/experience/experience";
 import BlogSection from "../sections/blog/blog";
+import YouTube from "../sections/youtube/youtube";
 import { Map } from "../sections/map/map";
 import type { BlogCard } from "../interfaces/blog";
+import type { YouTubeVideo } from "../interfaces/youtube";
 import { getSiteData, getAboutData, getBlogs } from "../lib/data";
+import { getYouTubeVideos } from "../lib/youtube";
 
 export async function getStaticProps(context) {
-  const [siteData, aboutData, blogs] = await Promise.all([
+  const [siteData, aboutData, blogs, youtubeVideos] = await Promise.all([
     getSiteData(),
     getAboutData(),
     getBlogs(),
+    getYouTubeVideos(6),
   ]);
 
   if (!siteData) {
@@ -29,6 +33,7 @@ export async function getStaticProps(context) {
       aboutData,
       bannerData: siteData.banner,
       blogs,
+      youtubeVideos,
       messages: (await import(`../messages/${context.locale}.json`)).default,
     },
     revalidate: 3600,
@@ -39,12 +44,14 @@ interface IndexPageProps {
   bannerData: any;
   aboutData: any;
   blogs: BlogCard[];
+  youtubeVideos: YouTubeVideo[];
 }
 
 export default function IndexPage({
   bannerData,
   aboutData,
   blogs,
+  youtubeVideos = [],
 }: IndexPageProps) {
   const countriesVisited = aboutData?.countriesVisited;
 
@@ -57,6 +64,7 @@ export default function IndexPage({
           <Experience experience={aboutData.experience} />
         )}
         {blogs && <BlogSection blogs={blogs} />}
+        <YouTube videos={youtubeVideos} />
         {countriesVisited && <Map countriesVisited={countriesVisited} />}
       </div>
     </>

--- a/sections/youtube/youtube.test.tsx
+++ b/sections/youtube/youtube.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import YouTube from "./youtube";
+import type { YouTubeVideo } from "../../interfaces/youtube";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} />
+  ),
+}));
+
+const videos: YouTubeVideo[] = [
+  {
+    id: "ndefUGEmywM",
+    title: "VIVID VILNIUS EPISODE 02",
+    url: "https://www.youtube.com/watch?v=ndefUGEmywM",
+    thumbnailUrl: "https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg",
+    publishedAt: "2026-04-27T15:24:04+00:00",
+  },
+  {
+    id: "l82IxaZMob0",
+    title: "EPISODE 01",
+    url: "https://www.youtube.com/watch?v=l82IxaZMob0",
+    thumbnailUrl: "https://i1.ytimg.com/vi/l82IxaZMob0/hqdefault.jpg",
+    publishedAt: "2026-04-19T09:08:08+00:00",
+  },
+];
+
+describe("YouTube section", () => {
+  it("renders nothing when there are no videos", () => {
+    const { container } = render(<YouTube videos={[]} />);
+
+    expect(container.querySelector("section")).not.toBeInTheDocument();
+  });
+
+  it("renders video cards with external links", () => {
+    render(<YouTube videos={videos} />);
+
+    expect(screen.getByRole("heading", { name: "Videos" })).toBeInTheDocument();
+    expect(screen.getByText("VIVID VILNIUS EPISODE 02")).toBeInTheDocument();
+    expect(screen.getByText("Apr 27, 2026")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "VIVID VILNIUS EPISODE 02 thumbnail" }),
+    ).toHaveAttribute(
+      "src",
+      "https://i3.ytimg.com/vi/ndefUGEmywM/hqdefault.jpg",
+    );
+
+    const links = screen.getAllByRole("link", { name: "Watch on YouTube" });
+    expect(links[0]).toHaveAttribute(
+      "href",
+      "https://www.youtube.com/watch?v=ndefUGEmywM",
+    );
+    expect(links[0]).toHaveAttribute("target", "_blank");
+    expect(links[0]).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/sections/youtube/youtube.tsx
+++ b/sections/youtube/youtube.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from "@prasheel/ui";
+import type { YouTubeVideo } from "../../interfaces/youtube";
+import Section from "../../components/tailwind/section";
+import { trackSelectContent } from "@/lib/gtag";
+
+const formatPublishedDate = (publishedAt: string) =>
+  new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(publishedAt));
+
+function YouTubeCard({ video }: { video: YouTubeVideo }) {
+  return (
+    <Card className="flex h-full flex-col transition-shadow hover:shadow-none hover:translate-x-boxShadowX hover:translate-y-boxShadowY">
+      <div className="relative aspect-video w-full overflow-hidden rounded-t-base bg-secondary-background">
+        <Image
+          src={video.thumbnailUrl}
+          alt={`${video.title} thumbnail`}
+          fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          className="object-cover"
+        />
+      </div>
+      <CardHeader className="flex-1">
+        <CardTitle className="line-clamp-2 text-base uppercase tracking-wide">
+          {video.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <p className="text-sm text-foreground">
+          {formatPublishedDate(video.publishedAt)}
+        </p>
+      </CardContent>
+      <CardFooter className="pt-0">
+        <Button variant="default" size="default" className="w-full" asChild>
+          <Link
+            href={video.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center gap-2 no-underline"
+            onClick={() =>
+              trackSelectContent({
+                section: "youtube_card",
+                content_type: "video",
+                item_id: video.id,
+                item_name: video.title,
+                link_url: video.url,
+                link_text: "Watch on YouTube",
+              })
+            }
+          >
+            Watch on YouTube
+            <ExternalLink className="size-4" aria-hidden="true" />
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+const itemBasis = (count: number) => {
+  if (count >= 4) return "md:basis-1/2 lg:basis-1/4";
+  if (count === 3) return "md:basis-1/2 lg:basis-1/3";
+  return "md:basis-1/2 lg:basis-1/3";
+};
+
+export default function YouTube({ videos }: { videos: YouTubeVideo[] }) {
+  if (videos.length === 0) return null;
+
+  return (
+    <Section container id="videos" heading="Videos">
+      <Carousel opts={{ align: "start" }}>
+        <CarouselContent>
+          {videos.map((video) => (
+            <CarouselItem key={video.id} className={itemBasis(videos.length)}>
+              <YouTubeCard video={video} />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </Carousel>
+    </Section>
+  );
+}

--- a/sections/youtube/youtube.tsx
+++ b/sections/youtube/youtube.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { motion } from "framer-motion";
 import { ExternalLink } from "lucide-react";
 import {
   Button,
@@ -28,50 +29,59 @@ const formatPublishedDate = (publishedAt: string) =>
 
 function YouTubeCard({ video }: { video: YouTubeVideo }) {
   return (
-    <Card className="flex h-full flex-col transition-shadow hover:shadow-none hover:translate-x-boxShadowX hover:translate-y-boxShadowY">
-      <div className="relative aspect-video w-full overflow-hidden rounded-t-base bg-secondary-background">
-        <Image
-          src={video.thumbnailUrl}
-          alt={`${video.title} thumbnail`}
-          fill
-          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          className="object-cover"
-        />
-      </div>
-      <CardHeader className="flex-1">
-        <CardTitle className="line-clamp-2 text-base uppercase tracking-wide">
-          {video.title}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pt-0">
-        <p className="text-sm text-foreground">
-          {formatPublishedDate(video.publishedAt)}
-        </p>
-      </CardContent>
-      <CardFooter className="pt-0">
-        <Button variant="default" size="default" className="w-full" asChild>
-          <Link
-            href={video.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center gap-2 no-underline"
-            onClick={() =>
-              trackSelectContent({
-                section: "youtube_card",
-                content_type: "video",
-                item_id: video.id,
-                item_name: video.title,
-                link_url: video.url,
-                link_text: "Watch on YouTube",
-              })
-            }
-          >
-            Watch on YouTube
-            <ExternalLink className="size-4" aria-hidden="true" />
-          </Link>
-        </Button>
-      </CardFooter>
-    </Card>
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-20px" }}
+      transition={{ duration: 0.3 }}
+      whileHover={{ y: -4, transition: { duration: 0.2 } }}
+      className="h-full"
+    >
+      <Card className="flex h-full flex-col transition-shadow hover:shadow-none hover:translate-x-boxShadowX hover:translate-y-boxShadowY">
+        <div className="relative aspect-video w-full overflow-hidden rounded-t-base bg-secondary-background">
+          <Image
+            src={video.thumbnailUrl}
+            alt={`${video.title} thumbnail`}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            className="object-cover"
+          />
+        </div>
+        <CardHeader className="flex-1">
+          <CardTitle className="line-clamp-2 text-base uppercase tracking-wide">
+            {video.title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <p className="text-sm text-foreground">
+            {formatPublishedDate(video.publishedAt)}
+          </p>
+        </CardContent>
+        <CardFooter className="pt-0">
+          <Button variant="default" size="default" className="w-full" asChild>
+            <Link
+              href={video.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 no-underline"
+              onClick={() =>
+                trackSelectContent({
+                  section: "youtube_card",
+                  content_type: "video",
+                  item_id: video.id,
+                  item_name: video.title,
+                  link_url: video.url,
+                  link_text: "Watch on YouTube",
+                })
+              }
+            >
+              Watch on YouTube
+              <ExternalLink className="size-4" aria-hidden="true" />
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds an automatic homepage Videos section powered by the public YouTube RSS feed for channel `UCbcnZGYObyzOZFe3elbyF9w`.

## Changes

- Fetch and parse YouTube Atom RSS server-side without Google Cloud or a YouTube API key.
- Render a homepage Videos carousel with thumbnails, publish dates, and external YouTube links.
- Hide the section if the feed is unavailable or returns no videos.
- Allow `ytimg.com` thumbnails through Next image remote patterns.
- Add tests for parsing, fallback behavior, section rendering, and homepage integration.

## Validation

- `npm run lint`
- `npm test` — 21 suites, 125 tests passed
- `npm run build`
- Local HTTP render confirmed `youtubeVideos` is populated from RSS.
